### PR TITLE
fix: missing dependency issue with next-papi when using pnpm

### DIFF
--- a/.github/workflows/package-manager.yml
+++ b/.github/workflows/package-manager.yml
@@ -44,12 +44,17 @@ jobs:
           CHANGED_TEMPLATES='${{ steps.filter.outputs.changes }}'
           echo "Changed templates: $CHANGED_TEMPLATES"
           
-          # Generate matrix for all changed templates
+          # Generate matrix for all changed templates with multiple package managers
           MATRIX=$(echo "$CHANGED_TEMPLATES" | jq -c '
             if . == [] then 
               {"include": []} 
             else 
-              {"include": [.[] | {"template": ., "working-directory": "templates/\(.)"}]} 
+              {"include": [
+                (.[] as $template | 
+                  ["npm", "yarn", "pnpm", "bun"] | .[] as $pm | 
+                  {"template": $template, "working-directory": "templates/\($template)", "package-manager": $pm}
+                )
+              ]} 
             end
           ' || echo '{"include": []}')
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
@@ -86,17 +91,33 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Install dependencies with npm
+      - name: Setup Yarn
+        if: matrix.package-manager == 'yarn'
+        run: npm install -g yarn
+
+      - name: Setup pnpm
+        if: matrix.package-manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Bun
+        if: matrix.package-manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
         working-directory: ${{ matrix.working-directory }}
-        run: npm install
+        run: ${{ matrix.package-manager }} install
 
       - name: Lint code
         working-directory: ${{ matrix.working-directory }}
-        run: npm run lint
+        run: ${{ matrix.package-manager }} run lint
 
-      - name: Build project with npm
+      - name: Build project
         working-directory: ${{ matrix.working-directory }}
-        run: npm run build
+        run: ${{ matrix.package-manager }} run build
 
   deno:
     needs: changes

--- a/templates/next-papi/app/page.tsx
+++ b/templates/next-papi/app/page.tsx
@@ -9,6 +9,7 @@ import { chainKeys } from './utils/sdk'
 
 export default function Home() {
   const { selectedAccount } = useConnect()
+  console.log('trigger build')
 
   return (
     <div className="min-h-screen flex flex-col justify-between">

--- a/templates/next-papi/app/page.tsx
+++ b/templates/next-papi/app/page.tsx
@@ -9,7 +9,6 @@ import { chainKeys } from './utils/sdk'
 
 export default function Home() {
   const { selectedAccount } = useConnect()
-  console.log('trigger build')
 
   return (
     <div className="min-h-screen flex flex-col justify-between">

--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -10,6 +10,7 @@
     "postinstall": "papi"
   },
   "dependencies": {
+    "@polkadot/util-crypto": "^13.5.6",
     "@talismn/connect-wallets": "^1.2.8",
     "@xstate/store": "^3.9.2",
     "next": "15.4.7",


### PR DESCRIPTION
## Summary

This PR enhances the CI/CD pipeline to test all templates with multiple package managers (npm, yarn, pnpm, bun) and fixes a pnpm-specific dependency issue in the next-papi template.

## Key Changes

### Enhanced CI Testing
- **Multi-Package Manager Matrix**: Tests each changed template with npm, yarn, pnpm, and bun
- **Proper Package Manager Setup**: Adds correct installation steps for yarn, pnpm, and bun
- **Dynamic Matrix Generation**: Creates test jobs only for changed templates with all package managers
- **Comprehensive Validation**: Runs lint and build commands across all package managers

### Dependency Fix  
- **Added Missing Dependency**: `@polkadot/util-crypto` to templates/next-papi/package.json
- **Resolves pnpm Issues**: Fixes missing dependency errors when using pnpm due to strict dependency resolution

## Impact

- **Better Compatibility**: Ensures templates work with users' preferred package managers
- **Early Issue Detection**: Catches package manager-specific problems in CI before release  
- **Enhanced Developer Experience**: Users can confidently use any supported package manager
- **Improved Reliability**: Multi-package manager testing increases confidence in template quality

## Testing

The enhanced workflow tests each template's lint and build processes with all four package managers, providing comprehensive compatibility validation and catching issues like missing peer dependencies early.