### PR TITLE
ci: trigger deployment

### DIFF
--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "@dedot/chaintypes": "^0.146.0",
+    "@dedot/chaintypes": "^0.151.0",
     "@eslint/eslintrc": "^3.3.1",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/token-branded": "^1.2.26",
@@ -27,8 +27,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "daisyui": "^5.0.54",
-    "eslint": "^9.34.0",
+    "daisyui": "^5.1.7",
+    "eslint": "^9.35.0",
     "eslint-config-next": "^15.5.2",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## Summary

Updates development dependencies in the next-dedot template to their latest stable versions:

- **@dedot/chaintypes**: ^0.146.0 → ^0.151.0 (minor version bump)
- **daisyui**: ^5.0.54 → ^5.1.7 (minor version bump)  
- **eslint**: ^9.34.0 → ^9.35.0 (minor version bump)

## What Changed
- All updates follow semantic versioning with patch/minor bumps
- Only devDependencies affected - no runtime impact
- Maintains compatibility with existing template codebase

## Why
- Keep dependencies current for latest security patches and bug fixes
- Ensure template users receive improved tooling and development experience
- Maintain ecosystem compatibility, especially with dedot library updates

## Testing
- Development-only dependencies with no expected runtime behavior changes
- Template builds and lints successfully with updated versions
- All deployments passing on Railway and Vercel preview environments