### PR TITLE
ci: test railway deployment

### DIFF
--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "@dedot/chaintypes": "^0.146.0",
+    "@dedot/chaintypes": "^0.151.0",
     "@eslint/eslintrc": "^3.3.1",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/token-branded": "^1.2.26",
@@ -27,8 +27,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "daisyui": "^5.0.54",
-    "eslint": "^9.34.0",
+    "daisyui": "^5.1.7",
+    "eslint": "^9.35.0",
     "eslint-config-next": "^15.5.2",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## 📦 Dependency Updates for Next.js DeDot Template

This PR updates several devDependencies in the templates/next-dedot template to their latest versions for improved functionality and security.

### 🔄 Updated Packages
- @dedot/chaintypes: 0.146.0 → 0.151.0 - Latest chain type definitions
- daisyui: 5.0.54 → 5.1.7 - UI component library updates  
- eslint: 9.34.0 → 9.35.0 - JavaScript linter improvements

### ✅ Why This Change
- Keeps dependencies current with latest bug fixes and improvements
- Maintains compatibility with existing codebase (minor/patch versions only)
- Supports ongoing Railway deployment testing

### 🚀 Impact
- No breaking changes expected
- Template remains fully functional
- Build and deployment processes unaffected

This is part of routine maintenance to ensure starter templates use up-to-date dependencies.