### PR TITLE
ci: railway watch paths

### DIFF
--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "@dedot/chaintypes": "^0.146.0",
+    "@dedot/chaintypes": "^0.151.0",
     "@eslint/eslintrc": "^3.3.1",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/token-branded": "^1.2.26",
@@ -27,8 +27,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "daisyui": "^5.0.54",
-    "eslint": "^9.34.0",
+    "daisyui": "^5.1.7",
+    "eslint": "^9.35.0",
     "eslint-config-next": "^15.5.2",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## Summary

Updates development dependencies in the Next.js Dedot template to their latest minor versions:

- **@dedot/chaintypes**: ^0.146.0 → ^0.151.0
- **daisyui**: ^5.0.54 → ^5.1.7  
- **eslint**: ^9.34.0 → ^9.35.0

## Changes Made

- Bumped three devDependencies to latest compatible versions
- All updates follow semantic versioning (minor version increments)
- No breaking changes expected

## Benefits

- Latest bug fixes and security patches
- Improved performance and new features
- Better compatibility with current ecosystem

## Testing

Template should be tested to ensure all dependencies work correctly together and the build process remains functional.