### PR TITLE
fix: vue/react only on bolt platform

### DIFF
--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -120,6 +120,13 @@ const buttonClass = computed(() => ({
   'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed': !isExportEnabled.value,
 }))
 
+const shouldShowPlatform = computed(() => (platform: string) => {
+  if (platform === 'bolt') {
+    return selectedFramework.value === 'react' || selectedFramework.value === 'vue' || !selectedFramework.value
+  }
+  return true
+})
+
 // Optimized status message
 const statusMessage = computed(() => {
   if (!selectedFramework.value && !selectedSdk.value) {
@@ -316,6 +323,7 @@ function exportTo(platform: keyof typeof platforms) {
             <div class="flex justify-center gap-4">
               <Button
                 v-for="(url, platform) in platforms"
+                v-show="shouldShowPlatform(platform)"
                 :key="platform"
                 variant="outline"
                 :class="buttonClass"


### PR DESCRIPTION


## Summary

This PR adds conditional visibility for the Bolt platform button based on the selected framework. The Bolt platform is now only displayed when React or Vue frameworks are selected, or when no framework is selected. This change ensures compatibility with Bolt's supported framework ecosystem.