### PR TITLE
test: split playwright tests into headless and headed modes

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 jobs:
-  test:
+  test-headless:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     
@@ -31,19 +31,61 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     
-    - name: Run Playwright tests
-      run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npx playwright test --reporter=html
+    - name: Run headless tests
+      run: npx playwright test tests/polkadot-starter-headless.spec.ts --reporter=html
     
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: playwright-report
+        name: playwright-report-headless
         path: playwright-report/
         retention-days: 30
     
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: playwright-test-results
+        name: playwright-test-results-headless
+        path: test-results/
+        retention-days: 30
+
+  test-headed:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    
+    env:
+      CI: true
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: latest
+    
+    - name: Install dependencies
+      run: bun install
+    
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    
+    - name: Run headed tests
+      run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npx playwright test tests/polkadot-starter-headed.spec.ts --reporter=html
+    
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report-headed
+        path: playwright-report/
+        retention-days: 30
+    
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-test-results-headed
         path: test-results/
         retention-days: 30

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "cda-cli",
       "devDependencies": {
-        "@avalix/chroma": "^0.0.3",
+        "@avalix/chroma": "^0.0.6",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.1",
         "@playwright/test": "^1.55.0",
@@ -13,7 +13,7 @@
     },
     "cli": {
       "name": "create-dot-app",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "bin": {
         "create-dot-app": "dist/index.js",
       },
@@ -43,7 +43,7 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@avalix/chroma": ["@avalix/chroma@0.0.3", "", { "dependencies": { "unzipper": "^0.12.3" }, "peerDependencies": { "@playwright/test": "^1.55.0" } }, "sha512-E9HRhj6ZJlOdJypYgRGfQFHt5svZefDuoM7exbh0lKxMeP5SPPp0r2gwijZADUmERtL5OzKGsPXKBK3JM2VHyQ=="],
+    "@avalix/chroma": ["@avalix/chroma@0.0.6", "", { "dependencies": { "unzipper": "^0.12.3" }, "peerDependencies": { "@playwright/test": "^1.55.0" } }, "sha512-oBoeSTR1pSx9f5xDqCXlQIhRMEzEI2ojxus4zISJKbe+ndN02xM/SlqkWgYNYsRCgZSB7gfvDP9ECENfByHkOg=="],
 
     "@babel/generator": ["@babel/generator@7.28.3", "", { "dependencies": { "@babel/parser": "^7.28.3", "@babel/types": "^7.28.2", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
-    "@avalix/chroma": "^0.0.3",
+    "@avalix/chroma": "^0.0.6",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "@playwright/test": "^1.55.0",

--- a/tests/polkadot-starter-headed.spec.ts
+++ b/tests/polkadot-starter-headed.spec.ts
@@ -1,0 +1,55 @@
+import { createWalletTest } from '@avalix/chroma';
+
+const POLKADOT_DAPP_URLS = [
+  'https://polkadot-starter-vue-dedot.vercel.app/',
+  'https://polkadot-starter-vue-papi.vercel.app/',
+]
+
+const ACCOUNT_NAME = '// Alice'
+const DOT_TEST_MNEMONIC = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk'
+const DOT_TEST_PASSWORD = 'secure123!'
+
+const test = createWalletTest({
+  headless: false,
+})
+
+test.describe.configure({ mode: 'serial' });
+
+POLKADOT_DAPP_URLS.forEach((url) => {
+  test(`sign transaction on ${url}`, async ({ page, importAccount, authorize, approveTx }) => {
+  console.log(`🧪 Testing ${url}`)
+  
+  await importAccount({
+    seed: DOT_TEST_MNEMONIC,
+    password: DOT_TEST_PASSWORD,
+    name: ACCOUNT_NAME,
+  })
+
+  await page.goto(url)
+  await page.waitForLoadState('networkidle')
+
+  await page.getByRole('button', { name: /Connect Wallet/i }).click()
+
+  const modalVisible = await page.locator('h2:has-text("CONNECT WALLET")').isVisible()
+  if (modalVisible) {
+    console.log('✅ Connect wallet modal opened')
+    // Click CONNECT button in modal
+    await page.getByRole('button', { name: /CONNECT/i }).nth(2).click()
+    console.log('🔗 Clicked CONNECT button')
+  }
+
+  await authorize()
+
+  await page.getByText(ACCOUNT_NAME).click()
+
+  await page.getByRole('button', { name: 'Sign Transaction' }).nth(3).click()
+  
+  if (url.includes('papi')) await page.waitForTimeout(3000)
+  await approveTx({ password: DOT_TEST_PASSWORD })
+  await page.getByText('Processing transaction...').waitFor({ state: 'visible' })
+
+  console.log(`🎉 Test completed successfully for ${url}!`)
+
+  await page.waitForTimeout(3000)
+  })
+})

--- a/tests/polkadot-starter-headless.spec.ts
+++ b/tests/polkadot-starter-headless.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@avalix/chroma';
+import { createWalletTest } from '@avalix/chroma';
 
 const POLKADOT_DAPP_URLS = [
   'https://polkadot-starter-vue-dedot.vercel.app/',
@@ -8,6 +8,10 @@ const POLKADOT_DAPP_URLS = [
 const ACCOUNT_NAME = '// Alice'
 const DOT_TEST_MNEMONIC = 'bottom drive obey lake curtain smoke basket hold race lonely fit walk'
 const DOT_TEST_PASSWORD = 'secure123!'
+
+const test = createWalletTest({
+  headless: true,
+})
 
 test.describe.configure({ mode: 'serial' });
 


### PR DESCRIPTION
## Overview

This PR improves the Playwright testing setup by splitting tests into separate headless and headed modes and updates the @avalix/chroma dependency.

## Changes

- **Update @avalix/chroma** from ^0.0.3 to ^0.0.6
- **Split Playwright tests** into separate files for better organization:
  - polkadot-starter-headless.spec.ts - runs in headless mode
  - polkadot-starter-headed.spec.ts - runs in headed mode with xvfb
- **Update GitHub Actions workflow** to run both test modes separately
- **Improve CI setup** with proper xvfb configuration for headed tests
- **Better artifact management** with separate reports for each test mode

## Benefits

- Better test isolation between headless and headed modes
- Improved CI reliability with proper display server setup
- Clearer test reporting and artifact separation
- Updated testing dependencies for better stability

---

## Review Summary

This PR successfully refactors Playwright tests into separate headless/headed modes with improved CI configuration. The @avalix/chroma dependency update (0.0.3 to 0.0.6) enhances stability. Main concerns: significant code duplication between test files (only headless flag differs), fragile nth() selectors, and hard-coded timeouts that may cause flakiness. The CI workflow properly separates jobs with distinct artifact naming and xvfb for headed tests. Consider consolidating duplicate test logic in a future refactor.