### PR TITLE
feat: generate dynamic package.json for solidity templates

### DIFF
--- a/.changeset/slimy-knives-complain.md
+++ b/.changeset/slimy-knives-complain.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": patch
+---
+
+feat: generate dynamic package.json for solidity templates

--- a/cli/src/downloader.ts
+++ b/cli/src/downloader.ts
@@ -39,7 +39,7 @@ async function downloadSolidityTemplate({ template, targetName = '.' }): Promise
   // Determine which dapp to download based on template
   const dappDir = template === 'solidity-react' ? 'dapp-react' : 'dapp-vue'
 
-  // Define subdirectories to download (excluding package.json, we'll create it dynamically)
+  // Define subdirectories to download
   const subdirs = [
     `templates/${SOLIDITY_BASE_TEMPLATE}/${dappDir}`,
     `templates/${SOLIDITY_BASE_TEMPLATE}/hardhat`,

--- a/templates/solidity-hardhat-wagmi/.gitignore
+++ b/templates/solidity-hardhat-wagmi/.gitignore
@@ -216,6 +216,3 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux,node
-
-bun.lock
-package-lock.json

--- a/templates/solidity-hardhat-wagmi/README.md
+++ b/templates/solidity-hardhat-wagmi/README.md
@@ -42,37 +42,54 @@ The template includes a **MessageBoard** contract that demonstrates:
 ### Prerequisites
 
 - Node.js 18+ 
-- npm or yarn package manager
+- npm, yarn, or bun package manager
+
+### Installation
+
+This project uses monorepo structure with workspaces. Install all dependencies from the root directory:
+
+```bash
+# Install all workspace dependencies
+npm install
+```
 
 ### 1. Smart Contract Development
 
 ```bash
-cd hardhat
-npm install
-
 # Deploy to Polkadot Asset Hub testnet
-npm run deploy
+npm run deploy -w hardhat
 
 # Interact with deployed contract
-npm run interact
+npm run interact -w hardhat
 
 # Verify contract
+npm run verify -w hardhat
+```
+
+Or navigate to the hardhat directory:
+
+```bash
+cd hardhat
+npm run deploy
+npm run interact
 npm run verify
 ```
 
-### 2. React Frontend
+### 2. Frontend Development
+
+Run the frontend application (React or Vue based on your selection):
 
 ```bash
-cd dapp-react
-npm install
-npm run dev
+# From root directory
+npm run dev -w dapp-react
+# or
+npm run dev -w dapp-vue
 ```
 
-### 3. Vue Frontend
+Or navigate to the frontend directory:
 
 ```bash
-cd dapp-vue
-npm install
+cd dapp-react  # or dapp-vue
 npm run dev
 ```
 
@@ -102,18 +119,24 @@ Both React and Vue applications include:
 
 ## Available Scripts
 
+You can run scripts from the root directory using the `-w` flag or navigate to the specific workspace.
+
 ### Hardhat
-- `npm run deploy` - Deploy contracts to testnet
-- `npm run interact` - Run interaction scripts
-- `npm run verify` - Verify deployed contracts
-- `npm run accounts` - Show account information
-- `npm run lint` - Run ESLint
+- `npm run deploy -w hardhat` - Deploy contracts to testnet
+- `npm run interact -w hardhat` - Run interaction scripts
+- `npm run verify -w hardhat` - Verify deployed contracts
+- `npm run accounts -w hardhat` - Show account information
+- `npm run lint -w hardhat` - Run ESLint
 
 ### Frontend (React/Vue)
-- `npm run dev` - Start development server
-- `npm run build` - Build for production
-- `npm run preview` - Preview production build
-- `npm run lint` - Run ESLint
+- `npm run dev -w dapp-react` - Start React dev server
+- `npm run dev -w dapp-vue` - Start Vue dev server
+- `npm run build -w dapp-react` - Build React for production
+- `npm run build -w dapp-vue` - Build Vue for production
+- `npm run preview -w dapp-react` - Preview React production build
+- `npm run preview -w dapp-vue` - Preview Vue production build
+- `npm run lint -w dapp-react` - Run ESLint for React
+- `npm run lint -w dapp-vue` - Run ESLint for Vue
 
 ## Technology Stack
 

--- a/templates/solidity-hardhat-wagmi/dapp-react/package.json
+++ b/templates/solidity-hardhat-wagmi/dapp-react/package.json
@@ -33,6 +33,7 @@
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
+    "minimatch": "^10.0.3",
     "typescript": "^5.9.2",
     "vite": "^7.1.7"
   }

--- a/templates/solidity-hardhat-wagmi/dapp-vue/package.json
+++ b/templates/solidity-hardhat-wagmi/dapp-vue/package.json
@@ -26,6 +26,7 @@
     "@vitejs/plugin-vue": "^6.0.1",
     "daisyui": "^5.1.25",
     "eslint": "^9.36.0",
+    "minimatch": "^10.0.3",
     "vite": "^7.1.7",
     "vue-tsc": "^3.0.8"
   }


### PR DESCRIPTION
## Changes

This PR improves the Solidity template setup by dynamically generating package.json with correct workspace configuration.

### What changed
- Package.json is now created dynamically based on selected dapp template
- Workspaces only include hardhat and the selected dapp (react or vue)
- Added `private: true` to prevent accidental npm publish
- Updated description to mention Polkadot ecosystem
- Removed static package.json from template directory

### Why
Previously, the static package.json included all workspaces (hardhat, dapp-react, dapp-vue) even when only one dapp was downloaded, causing workspace errors.

### Result
Users now get a clean package.json with only the workspaces they need for their selected template.