### PR TITLE
refactor: update hardhat polkadot plugin and remove unused dependencies

### DIFF
--- a/templates/solidity-hardhat-wagmi/hardhat/hardhat.config.ts
+++ b/templates/solidity-hardhat-wagmi/hardhat/hardhat.config.ts
@@ -2,7 +2,7 @@ import type { HardhatUserConfig } from 'hardhat/config'
 import process from 'node:process'
 import * as dotenv from 'dotenv'
 import '@nomicfoundation/hardhat-toolbox'
-import '@parity/hardhat-polkadot'
+import '@parity/hardhat-polkadot-resolc'
 
 // Load environment variables from .env.development file
 // Override with .env file if it exists
@@ -11,18 +11,6 @@ dotenv.config({ path: ['.env.development', '.env'], override: true })
 // https://docs.polkadot.com/develop/smart-contracts/dev-environments/hardhat/
 const config: HardhatUserConfig = {
   solidity: '0.8.28',
-  resolc: {
-    compilerSource: 'npm',
-    settings: {
-      optimizer: {
-        enabled: true,
-        parameters: 'z',
-        fallbackOz: true,
-        runs: 200,
-      },
-      // standardJson: true,
-    },
-  },
   networks: {
     hardhat: {
       polkavm: true,

--- a/templates/solidity-hardhat-wagmi/hardhat/package.json
+++ b/templates/solidity-hardhat-wagmi/hardhat/package.json
@@ -20,10 +20,8 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.3.0",
-    "@parity/hardhat-polkadot": "0.1.9",
+    "@parity/hardhat-polkadot-resolc": "0.1.8",
     "eslint": "^9.35.0",
-    "fs-xattr": "^0.4.0",
-    "run-container": "^2.0.12",
     "solc": "0.8.28"
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the Hardhat Polkadot plugin configuration and removes unused dependencies to streamline the project setup.

## Changes

- **Updated Hardhat Plugin**: Switched from `@parity/hardhat-polkadot` to `@parity/hardhat-polkadot-resolc`
- **Removed Configuration**: Removed the `resolc` configuration block from hardhat.config.ts as it's no longer needed
- **Cleaned Dependencies**: Removed unused dependencies: `fs-xattr` and `run-container`

## Impact

- Simplifies the hardhat configuration
- Reduces bundle size by removing unused dependencies
- Uses the more specific resolc plugin for better compatibility