### PR TITLE
chore(templates/next): update dependencies and configuration

### DIFF
--- a/templates/next-dedot/app/globals.css
+++ b/templates/next-dedot/app/globals.css
@@ -1,9 +1,12 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 @plugin "@iconify/tailwind4";
-@plugin "daisyui";
 
 .container {
   max-width: 1200px;
+}
+
+@plugin "daisyui" {
+  exclude: properties;
 }
 
 /* to enable dark mode, remove data-theme="light" from html tag */

--- a/templates/next-dedot/eslint.config.mjs
+++ b/templates/next-dedot/eslint.config.mjs
@@ -1,13 +1,8 @@
-import { FlatCompat } from '@eslint/eslintrc'
-
-const compat = new FlatCompat({
-  baseDirectory: import.meta.dirname,
-})
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const config = [{
-  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts"]
-}, ...compat.config({
-  extends: ['next/core-web-vitals', 'next/typescript'],
-})]
+  ignores: ['app/descriptors/**'],
+}, ...nextCoreWebVitals, ...nextTypescript]
 
 export default config

--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -10,27 +10,27 @@
   },
   "dependencies": {
     "@talismn/connect-wallets": "^1.2.8",
-    "@xstate/store": "^3.9.3",
-    "dedot": "^0.18.2",
-    "next": "15.5.4",
-    "react": "19.1.1",
-    "react-dom": "19.1.1"
+    "@xstate/store": "^3.11.2",
+    "dedot": "^0.18.5",
+    "next": "16.0.1",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
-    "@dedot/chaintypes": "^0.161.0",
-    "@eslint/eslintrc": "^3.3.1",
+    "@dedot/chaintypes": "^0.181.0",
     "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/token-branded": "^1.2.28",
-    "@iconify/tailwind4": "^1.0.6",
-    "@next/eslint-plugin-next": "^15.5.4",
-    "@tailwindcss/postcss": "^4.1.14",
-    "@types/node": "^24.7.0",
-    "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.1",
-    "daisyui": "^5.1.29",
-    "eslint": "^9.37.0",
-    "eslint-config-next": "^15.5.4",
-    "tailwindcss": "^4.1.14",
-    "typescript": "^5.9.3"
-  }
+    "@iconify-json/token-branded": "^1.2.32",
+    "@iconify/tailwind4": "^1.1.0",
+    "@next/eslint-plugin-next": "^16.0.1",
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "daisyui": "^5.4.7",
+    "eslint": "^9.39.1",
+    "eslint-config-next": "^16.0.1",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  },
+  "browserslist": "> 1%"
 }

--- a/templates/next-dedot/tsconfig.json
+++ b/templates/next-dedot/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/templates/next-papi/app/globals.css
+++ b/templates/next-papi/app/globals.css
@@ -1,9 +1,12 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 @plugin "@iconify/tailwind4";
-@plugin "daisyui";
 
 .container {
   max-width: 1200px;
+}
+
+@plugin "daisyui" {
+  exclude: properties;
 }
 
 /* to enable dark mode, remove data-theme="light" from html tag */

--- a/templates/next-papi/eslint.config.mjs
+++ b/templates/next-papi/eslint.config.mjs
@@ -1,16 +1,8 @@
-import { FlatCompat } from '@eslint/eslintrc'
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
-const compat = new FlatCompat({
-  baseDirectory: import.meta.dirname,
-})
-
-const config = [
-  {
-    ignores: ['app/descriptors/**'],
-  },
-  ...compat.config({
-    extends: ['next/core-web-vitals', 'next/typescript'],
-  }),
-]
+const config = [{
+  ignores: ['app/descriptors/**'],
+}, ...nextCoreWebVitals, ...nextTypescript]
 
 export default config

--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -6,32 +6,32 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --fix",
+    "lint": "eslint --fix .",
     "postinstall": "papi"
   },
   "dependencies": {
     "@polkadot-api/react-components": "^0.4.1",
     "@talismn/connect-wallets": "^1.2.8",
-    "@xstate/store": "^3.9.2",
-    "next": "15.5.2",
-    "polkadot-api": "^1.16.3",
-    "react": "19.1.1",
-    "react-dom": "19.1.1"
+    "@xstate/store": "^3.11.2",
+    "next": "16.0.1",
+    "polkadot-api": "^1.20.2",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.1",
     "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/token-branded": "^1.2.26",
-    "@iconify/tailwind4": "^1.0.6",
-    "@next/eslint-plugin-next": "^15.5.2",
+    "@iconify-json/token-branded": "^1.2.32",
+    "@iconify/tailwind4": "^1.1.0",
+    "@next/eslint-plugin-next": "^16.0.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "daisyui": "^5.0.54",
-    "eslint": "^9.34.0",
-    "eslint-config-next": "^15.5.2",
+    "daisyui": "^5.4.7",
+    "eslint": "^9.39.1",
+    "eslint-config-next": "^16.0.1",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "browserslist": "> 1%"
 }

--- a/templates/next-papi/tsconfig.json
+++ b/templates/next-papi/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This PR updates dependencies and configuration files for both next-papi and next-dedot templates.

## Changes
- Update Next.js to 16.0.1 and React to 19.2.0
- Update ESLint config to use direct imports instead of FlatCompat
- Configure daisyui plugin with exclude properties
- Update TypeScript config formatting and jsx setting
- Add browserslist to package.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades Next.js/React and dependencies, and streamlines ESLint, TypeScript, and DaisyUI configurations across both templates.
> 
> - **Dependencies**:
>   - Bump `next` to `16.0.1`, `react`/`react-dom` to `19.2.0`, and update related libs (`@xstate/store`, `dedot`, `polkadot-api`, `daisyui`, `eslint*`, `@iconify/*`, types) in both `templates/next-dedot` and `templates/next-papi`.
>   - Add `browserslist` to each `package.json`.
> - **ESLint**:
>   - Replace FlatCompat with direct `eslint-config-next` imports; keep ignores to `app/descriptors/**` in both templates.
>   - Align `lint` script to `eslint --fix .` in `next-papi`.
> - **TypeScript**:
>   - Switch `jsx` to `react-jsx`; expand `include` to add `.next/dev/types/**/*.ts` in both templates.
> - **CSS/Theming**:
>   - Configure `@plugin "daisyui" { exclude: properties; }` and retain `daisyui/theme` setup in both `app/globals.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a08df10a8480e53bd7a99e1538821c1e2232851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->