### PR TITLE
feat: add template selector components and composable

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cda-cli",

--- a/docs/app/components/ContractTypeSelector.vue
+++ b/docs/app/components/ContractTypeSelector.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+const { contractType, contractTypes, selectContractType } = useTemplateSelector()
+
+function selectionButtonClass(isSelected: boolean) {
+  return {
+    'bg-black text-white border-black': isSelected,
+    'bg-white border-gray-200 hover:border-gray-300 hover:shadow-md': !isSelected,
+  }
+}
+</script>
+
+<template>
+  <div class="mb-8">
+    <h3 class="text-lg font-semibold mb-4 text-black text-center">
+      [Step 1: Choose Contract Type]
+    </h3>
+    <div class="grid md:grid-cols-3 gap-4">
+      <button
+        v-for="type in contractTypes"
+        :key="type.id"
+        class="p-6 rounded-lg border-2 text-left transition-all duration-200 transform hover:scale-105"
+        :class="selectionButtonClass(contractType === type.id)"
+        @click="selectContractType(type.id)"
+      >
+        <div class="flex items-start justify-between mb-2">
+          <h4 class="font-semibold text-base">
+            {{ type.name }}
+          </h4>
+          <span v-if="contractType === type.id" class="text-white">✓</span>
+        </div>
+        <p class="text-sm" :class="contractType === type.id ? 'text-gray-200' : 'text-gray-600'">
+          {{ type.description }}
+        </p>
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/app/components/FrameworkSdkSelector.vue
+++ b/docs/app/components/FrameworkSdkSelector.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+const {
+  contractType,
+  selectedFramework,
+  selectedSdk,
+  availableFrameworks,
+  availableSdks,
+  needsSdkSelection,
+  selectFramework,
+  selectSdk,
+} = useTemplateSelector()
+
+function selectionButtonClass(isSelected: boolean) {
+  return {
+    'bg-black text-white': isSelected,
+    'bg-gray-50': !isSelected,
+  }
+}
+</script>
+
+<template>
+  <Transition
+    enter-active-class="transition-all duration-300 ease-out"
+    enter-from-class="opacity-0 transform -translate-y-4"
+    enter-to-class="opacity-100 transform translate-y-0"
+    leave-active-class="transition-all duration-200 ease-in"
+    leave-from-class="opacity-100 transform translate-y-0"
+    leave-to-class="opacity-0 transform -translate-y-4"
+  >
+    <div v-if="contractType" class="grid gap-8 mb-8" :class="needsSdkSelection ? 'md:grid-cols-2' : 'md:grid-cols-1'">
+      <div class="bg-white border border-gray-200 rounded-lg p-6">
+        <h3 class="text-lg font-semibold mb-4 text-black text-center">
+          [Step 2: Choose Framework]
+        </h3>
+      <div class="grid grid-cols-2 gap-2">
+        <button
+          v-for="framework in availableFrameworks"
+          :key="framework.id"
+          class="flex items-center gap-2 p-3 rounded text-sm transition-colors"
+          :class="selectionButtonClass(selectedFramework === framework.id)"
+          @click="selectFramework(framework.id)"
+        >
+          <span
+            class="w-5 h-5 flex-shrink-0"
+            :class="{
+              'icon-[logos--react]': framework.id === 'react',
+              'icon-[logos--nextjs-icon]': framework.id === 'next',
+              'icon-[logos--vue]': framework.id === 'vue',
+              'icon-[logos--nuxt-icon]': framework.id === 'nuxt',
+            }"
+          />
+          <span class="flex-1 text-left">{{ framework.name }}</span>
+          <span v-if="selectedFramework === framework.id" class="text-white">✓</span>
+          <span v-else class="text-gray-500">○</span>
+        </button>
+      </div>
+    </div>
+
+      <div v-if="needsSdkSelection" class="bg-white border border-gray-200 rounded-lg p-6">
+        <h3 class="text-lg font-semibold mb-4 text-black text-center">
+          [Step 3: Select SDK]
+        </h3>
+      <div class="space-y-2">
+        <button
+          v-for="sdk in availableSdks"
+          :key="sdk.id"
+          class="w-full flex items-center gap-2 p-3 rounded text-sm transition-colors"
+          :class="selectionButtonClass(selectedSdk === sdk.id)"
+          @click="selectSdk(sdk.id)"
+        >
+          <span class="w-5 h-5 flex-shrink-0 icon-[token-branded--polkadot]" />
+          <span class="flex-1 text-left">{{ sdk.name }}</span>
+          <span v-if="selectedSdk === sdk.id" class="text-white">✓</span>
+          <span v-else class="text-gray-500">○</span>
+        </button>
+      </div>
+    </div>
+    </div>
+  </Transition>
+</template>
+

--- a/docs/app/composables/useTemplateSelector.ts
+++ b/docs/app/composables/useTemplateSelector.ts
@@ -1,0 +1,203 @@
+type ContractType = '' | 'substrate' | 'solidity' | 'ink'
+
+const CONTRACT_TYPES = [
+  { id: 'substrate' as const, name: 'Substrate Pallets', description: 'Build with Dedot or PAPI SDK' },
+  { id: 'solidity' as const, name: 'Solidity Contracts', description: 'EVM-compatible smart contracts' },
+  { id: 'ink' as const, name: 'ink! Contracts', description: 'Rust smart contracts' },
+] as const
+
+const FRAMEWORKS = {
+  react: { id: 'react', name: 'React.js' },
+  next: { id: 'next', name: 'Next.js' },
+  vue: { id: 'vue', name: 'Vue.js' },
+  nuxt: { id: 'nuxt', name: 'Nuxt.js' },
+} as const
+
+const SDKS = {
+  dedot: { id: 'dedot', name: 'Dedot' },
+  papi: { id: 'papi', name: 'PAPI' },
+} as const
+
+const FRAMEWORKS_BY_TYPE = {
+  substrate: [FRAMEWORKS.react, FRAMEWORKS.next, FRAMEWORKS.vue, FRAMEWORKS.nuxt],
+  solidity: [FRAMEWORKS.react, FRAMEWORKS.vue],
+  ink: [FRAMEWORKS.react, FRAMEWORKS.vue],
+} as const
+
+const SDKS_BY_TYPE = {
+  substrate: [SDKS.dedot, SDKS.papi],
+  ink: [SDKS.dedot, SDKS.papi],
+} as const
+
+const PLATFORMS = {
+  bolt: 'https://bolt.new',
+  stackblitz: 'https://stackblitz.com',
+  codesandbox: 'https://codesandbox.io/s',
+} as const
+
+export function useTemplateSelector() {
+  const contractType = useState<ContractType>('contractType', () => '')
+  const selectedFramework = useState<string>('selectedFramework', () => '')
+  const selectedSdk = useState<string>('selectedSdk', () => '')
+  const copied = useState<boolean>('copied', () => false)
+  const showValidationMessage = useState<boolean>('showValidationMessage', () => false)
+  const validationMessage = useState<string>('validationMessage', () => '')
+
+  const availableFrameworks = computed(() => {
+    const type = contractType.value as keyof typeof FRAMEWORKS_BY_TYPE
+    return FRAMEWORKS_BY_TYPE[type] || []
+  })
+
+  const availableSdks = computed(() => {
+    const type = contractType.value as keyof typeof SDKS_BY_TYPE
+    return SDKS_BY_TYPE[type] || []
+  })
+
+  const needsSdkSelection = computed(() => availableSdks.value.length > 0)
+
+  const templateName = computed(() => {
+    if (!contractType.value || !selectedFramework.value)
+      return ''
+
+    const framework = selectedFramework.value
+    const sdk = selectedSdk.value || 'dedot'
+
+    const templateMap: Record<ContractType, string> = {
+      '': '',
+      'substrate': `${framework}-${sdk}`,
+      'solidity': `solidity-${framework}`,
+      'ink': `ink-v6/${framework}-${sdk}`,
+    }
+
+    return templateMap[contractType.value]
+  })
+
+  const command = computed(() => {
+    const base = 'npx create-dot-app@latest'
+    return templateName.value ? `${base} --template=${templateName.value}` : base
+  })
+
+  const isSelectionComplete = computed(() => {
+    if (!contractType.value || !selectedFramework.value)
+      return false
+    if (needsSdkSelection.value && !selectedSdk.value)
+      return false
+    return true
+  })
+
+  const isExportEnabled = computed(() => {
+    return contractType.value === 'substrate' && selectedFramework.value && selectedSdk.value
+  })
+
+  const buttonClass = computed(() => ({
+    'border-gray-300 text-gray-700 hover:bg-gray-50 bg-transparent': isExportEnabled.value,
+    'border-gray-200 text-gray-400 bg-gray-50 cursor-not-allowed': !isExportEnabled.value,
+  }))
+
+  const shouldShowPlatform = computed(() => (platform: string) => {
+    if (platform === 'bolt') {
+      return selectedFramework.value === 'react' || selectedFramework.value === 'vue' || !selectedFramework.value
+    }
+    return true
+  })
+
+  async function copyCommand() {
+    try {
+      await navigator.clipboard.writeText(command.value)
+      copied.value = true
+      setTimeout(() => {
+        copied.value = false
+      }, 2000)
+    }
+    catch (err) {
+      console.error('Failed to copy: ', err)
+    }
+  }
+
+  function selectContractType(type: ContractType) {
+    contractType.value = type
+    selectedFramework.value = ''
+    selectedSdk.value = ''
+  }
+
+  function selectFramework(frameworkId: string) {
+    selectedFramework.value = selectedFramework.value === frameworkId ? '' : frameworkId
+
+    if (isSelectionComplete.value) {
+      copyCommand()
+    }
+  }
+
+  function selectSdk(sdkId: string) {
+    selectedSdk.value = selectedSdk.value === sdkId ? '' : sdkId
+
+    if (isSelectionComplete.value) {
+      copyCommand()
+    }
+  }
+
+  function resetSelection() {
+    contractType.value = ''
+    selectedFramework.value = ''
+    selectedSdk.value = ''
+  }
+
+  function validateAndGetTemplate() {
+    if (contractType.value === 'substrate' && (!selectedFramework.value || !selectedSdk.value)) {
+      const missingSelections = []
+      if (!selectedFramework.value)
+        missingSelections.push('framework')
+      if (!selectedSdk.value)
+        missingSelections.push('SDK')
+
+      validationMessage.value = `Please select a ${missingSelections.join(' and ')} before exporting.`
+      showValidationMessage.value = true
+
+      setTimeout(() => {
+        showValidationMessage.value = false
+      }, 3000)
+
+      return null
+    }
+
+    return templateName.value || null
+  }
+
+  function exportTo(platform: keyof typeof PLATFORMS) {
+    const template = validateAndGetTemplate()
+    if (!template)
+      return
+
+    const baseUrl = PLATFORMS[platform]
+    const url = `${baseUrl}/github/preschian/create-dot-app/tree/main/templates/${template}`
+    const newWindow = window.open(url, '_blank', 'noopener,noreferrer')
+    if (newWindow)
+      newWindow.opener = null
+  }
+
+  return {
+    contractType,
+    contractTypes: CONTRACT_TYPES,
+    selectedFramework,
+    selectedSdk,
+    copied,
+    showValidationMessage,
+    validationMessage,
+    availableFrameworks,
+    availableSdks,
+    needsSdkSelection,
+    isSelectionComplete,
+    command,
+    isExportEnabled,
+    buttonClass,
+    shouldShowPlatform,
+    copyCommand,
+    selectContractType,
+    selectFramework,
+    selectSdk,
+    resetSelection,
+    validateAndGetTemplate,
+    platforms: PLATFORMS,
+    exportTo,
+  }
+}

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "nuxt-app",
@@ -10,6 +11,7 @@
         "@nuxt/icon": "1.13.0",
         "@tailwindcss/vite": "^4.1.13",
         "@vueuse/core": "^13.9.0",
+        "caniuse-lite": "^1.0.30001754",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-vue-next": "^0.544.0",
@@ -783,7 +785,7 @@
 
     "caniuse-api": ["caniuse-api@3.0.0", "", { "dependencies": { "browserslist": "^4.0.0", "caniuse-lite": "^1.0.0", "lodash.memoize": "^4.1.2", "lodash.uniq": "^4.5.0" } }, "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001754", "", {}, "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -2187,6 +2189,8 @@
 
     "autoprefixer/browserslist": ["browserslist@4.25.0", "", { "dependencies": { "caniuse-lite": "^1.0.30001718", "electron-to-chromium": "^1.5.160", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA=="],
 
+    "autoprefixer/caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
+
     "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001741", "", {}, "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw=="],
 
     "c12/dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
@@ -2196,6 +2200,8 @@
     "c12/perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "caniuse-api/browserslist": ["browserslist@4.25.0", "", { "dependencies": { "caniuse-lite": "^1.0.30001718", "electron-to-chromium": "^1.5.160", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA=="],
+
+    "caniuse-api/caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -2418,6 +2424,8 @@
     "@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@babel/generator/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
 
     "@babel/helper-compilation-targets/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.165", "", {}, "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw=="],
 
@@ -2888,6 +2896,8 @@
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "stylehacks/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001721", "", {}, "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ=="],
 
     "stylehacks/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.165", "", {}, "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "@nuxt/icon": "1.13.0",
     "@tailwindcss/vite": "^4.1.13",
     "@vueuse/core": "^13.9.0",
+    "caniuse-lite": "^1.0.30001754",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-vue-next": "^0.544.0",


### PR DESCRIPTION
Adds new template selector functionality with ContractTypeSelector and FrameworkSdkSelector components, along with a useTemplateSelector composable for managing template selection state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a composable-based template selector with new components and refactors the docs index to support contract type, framework, and SDK selection with copy/export actions.
> 
> - **Docs App**:
>   - **Composable**: Add `useTemplateSelector` managing selection state (`contractType`, `framework`, `sdk`), computed `command/template`, validation, copy-to-clipboard, and export URLs.
>   - **Components**: Add `ContractTypeSelector.vue` and `FrameworkSdkSelector.vue` for stepwise selection UI.
>   - **Refactor**: Replace inline selection logic in `pages/index.vue` with the new composable/components; simplify command/status rendering and gate "Try Online" to `substrate`.
> - **Dependencies**:
>   - Add `caniuse-lite` to `docs/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e7abd0ca235edc1bfca9faf94f143bfb825664d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->