### PR TITLE
feat(next): npm workspaces for Hardhat contracts

### DIFF
--- a/templates/next/README.md
+++ b/templates/next/README.md
@@ -21,6 +21,8 @@ Router's server component architecture.
 
 ### 1. Install dependencies
 
+Installs the Next.js app and the Hardhat workspace under `contracts/` (npm workspaces).
+
 ```bash
 npm install
 ```
@@ -72,22 +74,24 @@ Providers and chain config:
 
 ## Smart contracts
 
-The [`contracts/`](contracts/) directory is a [Hardhat](https://docs.polkadot.com/smart-contracts/dev-environments/hardhat/) workspace for Polkadot Hub (same TestNet as the dapp). See [`contracts/README.md`](contracts/README.md).
+The [`contracts/`](contracts/) directory is a [Hardhat](https://docs.polkadot.com/smart-contracts/dev-environments/hardhat/) workspace (`hardhat`) in the same npm monorepo as the app. See [`contracts/README.md`](contracts/README.md).
 
 ```bash
-cd contracts
-npm install
-npm run compile
-npm test
+npm run compile:contracts
+npm run test:contracts
+npm run deploy:contracts   # requires PRIVATE_KEY — see contracts/README.md
 ```
 
 ## Scripts
 
 ```bash
-npm run dev     # start the dev server
-npm run build   # production build
-npm run start   # serve the production build
-npm run lint    # eslint (includes @typescript-eslint/no-deprecated for wagmi/viem APIs)
+npm run dev                # start the dev server
+npm run build              # production build
+npm run start              # serve the production build
+npm run lint               # eslint (includes @typescript-eslint/no-deprecated for wagmi/viem APIs)
+npm run compile:contracts  # compile Solidity and export ABIs to lib/contracts/
+npm run test:contracts     # Hardhat tests
+npm run deploy:contracts   # deploy Flipper + Remark to Polkadot Hub TestNet
 ```
 
 `npm run lint` fails on wagmi symbols marked `@deprecated` in their types (for example `useAccount`, `switchChain`, `writeContract` on hook results). Use `useConnection`, `mutate` from `useSwitchChain` / `useWriteContract`, and similar replacements from the [wagmi migration guide](https://wagmi.sh/react/guides/migrate-from-v2-to-v3).

--- a/templates/next/components/welcome/LiveDemo.tsx
+++ b/templates/next/components/welcome/LiveDemo.tsx
@@ -267,7 +267,7 @@ export function LiveDemo({ C, acc, mono, body, disp, net, onSwitch }: Props) {
               <p style={{ fontFamily: body, fontSize: 13, lineHeight: 1.5, color: C.dim, margin: "6px 0 0" }}>
                 Run{" "}
                 <span style={{ fontFamily: mono, fontSize: 12, color: acc }}>
-                  cd contracts && npm run deploy
+                  npm run deploy:contracts
                 </span>{" "}
                 then set <span style={{ fontFamily: mono, fontSize: 12, color: acc }}>{missingContractName}</span> in{" "}
                 <span style={{ fontFamily: mono, fontSize: 12, color: acc }}>lib/contracts/addresses.ts</span> (testnet).

--- a/templates/next/contracts/README.md
+++ b/templates/next/contracts/README.md
@@ -11,18 +11,29 @@ The default network (`polkadotTestnet`) matches **Polkadot Hub TestNet** used by
 
 ## Setup
 
+From the **project root** (monorepo — `npm install` installs this workspace too):
+
 ```bash
-cd contracts
 npm install
 ```
 
-Store your deployer private key with Hardhat vars (recommended):
+Store your deployer private key with Hardhat vars (recommended). Run from the project root or from `contracts/`:
 
 ```bash
-npx hardhat vars set PRIVATE_KEY
+npm exec -w hardhat hardhat vars set PRIVATE_KEY
 ```
 
 ## Scripts
+
+From the project root:
+
+```bash
+npm run compile:contracts
+npm run test:contracts
+npm run deploy:contracts
+```
+
+Or from this directory (`contracts/`):
 
 ```bash
 npm run compile   # compile Solidity and export ABIs to ../lib/contracts/
@@ -37,8 +48,8 @@ Deploy requires `PRIVATE_KEY` to be set and the account funded with test PAS.
 After deployment:
 
 ```bash
-npx hardhat verify --network polkadotTestnet <FLIPPER_ADDRESS> false
-npx hardhat verify --network polkadotTestnet <REMARK_ADDRESS>
+npm exec -w hardhat hardhat verify --network polkadotTestnet <FLIPPER_ADDRESS> false
+npm exec -w hardhat hardhat verify --network polkadotTestnet <REMARK_ADDRESS>
 ```
 
 Copy the deployed testnet addresses into [`../lib/contracts/addresses.ts`](../lib/contracts/addresses.ts) (mainnet and Kusama Hub can stay unset).

--- a/templates/next/contracts/package.json
+++ b/templates/next/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-contracts",
+  "name": "hardhat",
   "version": "0.1.0",
   "private": true,
   "description": "Hardhat workspace for Polkadot Hub smart contracts",

--- a/templates/next/lib/contracts/addresses.ts
+++ b/templates/next/lib/contracts/addresses.ts
@@ -4,7 +4,7 @@ const id = (chain: { chainId: string }) => Number.parseInt(chain.chainId, 16)
 
 /**
  * Deployed demo contracts per Polkadot Hub EVM chain.
- * Set testnet addresses after `cd contracts && npm run deploy`.
+ * Set testnet addresses after `npm run deploy:contracts`.
  * Mainnet and Kusama Hub stay unset until you deploy there.
  */
 export const FLIPPER_ADDRESS_BY_CHAIN_ID: Record<number, `0x${string}` | undefined> = {

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -1,12 +1,18 @@
 {
-  "name": "nextjs-quick-start",
+  "name": "next-hub",
   "version": "0.1.0",
   "private": true,
+  "workspaces": [
+    "contracts"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "compile:contracts": "npm run compile -w hardhat",
+    "test:contracts": "npm run test -w hardhat",
+    "deploy:contracts": "npm run deploy -w hardhat"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.14",


### PR DESCRIPTION
## Summary

- Add npm workspaces to `templates/next` so `npm install` at the project root installs both the Next.js app and the Hardhat package under `contracts/`.
- Add root scripts: `compile:contracts`, `test:contracts`, `deploy:contracts` (delegating to `-w hardhat`).
- Rename workspace packages for clarity: root `next-hub`, contracts workspace `hardhat` (replacing `nextjs-quick-start` / `next-contracts`).
- Update README, contracts README, LiveDemo copy, and addresses comment to match the new workflow.

## Test plan

- [x] `cd templates/next && npm install`
- [x] `npm run test:contracts`
- [x] `npm run compile:contracts`
- [x] `npm run dev` still starts the app


Made with [Cursor](https://cursor.com)