### PR TITLE
feat(cli): post-scaffold DX, fix non-npm installs, support npm/yarn/pnpm/bun

### DIFF
--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package-manager: [npm, bun]
+        package-manager: [npm, yarn, pnpm, bun]
         working-directory: ${{ fromJson(needs.generate-matrix.outputs.templates) }}
     
     steps:
@@ -42,6 +42,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Setup pnpm
+        if: matrix.package-manager == 'pnpm'
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
 
       - name: Install dependencies with ${{ matrix.package-manager }}
         working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package-manager: [npm, pnpm, bun, yarn]
+        package-manager: [npm, bun]
         working-directory: ${{ fromJson(needs.generate-matrix.outputs.templates) }}
     
     steps:
@@ -36,12 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-
-      - name: Setup pnpm
-        if: matrix.package-manager == 'pnpm'
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Bun
         if: matrix.package-manager == 'bun'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npx create-dot-app@latest my-dapp --template react-papi
 - 🚀 **Multiple Frameworks** - React, Vue, Next.js, Nuxt
 - 🔗 **Dual SDK Support** - [PAPI](https://papi.how/) and [Dedot](https://docs.dedot.dev/)
 - 🔨 **Smart Contracts** - Substrate Pallets, Solidity
-- 📦 **Package Managers** - npm, yarn, pnpm, bun, deno
+- 📦 **Package Managers** - npm, bun
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npx create-dot-app@latest my-dapp --template react-papi
 - 🚀 **Multiple Frameworks** - React, Vue, Next.js, Nuxt
 - 🔗 **Dual SDK Support** - [PAPI](https://papi.how/) and [Dedot](https://docs.dedot.dev/)
 - 🔨 **Smart Contracts** - Substrate Pallets, Solidity
-- 📦 **Package Managers** - npm, bun
+- 📦 **Package Managers** - npm, yarn, pnpm, bun
 
 ## Documentation
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ A command-line interface (CLI) tool designed to streamline the development proce
 - **Solidity** smart contracts via an integrated Hardhat workspace (Polkadot Hub)
 
 ### 📦 Package Manager Support
-Compatible with npm and bun
+Compatible with npm, yarn, pnpm, and bun
 
 ### 📋 Planned Templates
 
@@ -116,7 +116,7 @@ For more details about testing, see [TESTING.md](./TESTING.md).
 
 The project uses GitHub Actions for continuous integration:
 - **CLI E2E Tests**: Automated tests for all templates and features
-- **Package Manager Tests**: Tests template installations with npm and bun
+- **Package Manager Tests**: Tests template installations with npm, yarn, pnpm, and bun
 - **Automated Releases**: Publishes to npm on version tags
 
 ## Contributing

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ A command-line interface (CLI) tool designed to streamline the development proce
 - **Solidity** smart contracts via an integrated Hardhat workspace (Polkadot Hub)
 
 ### 📦 Package Manager Support
-Compatible with npm, yarn, pnpm, bun, and deno
+Compatible with npm and bun
 
 ### 📋 Planned Templates
 
@@ -116,7 +116,7 @@ For more details about testing, see [TESTING.md](./TESTING.md).
 
 The project uses GitHub Actions for continuous integration:
 - **CLI E2E Tests**: Automated tests for all templates and features
-- **Package Manager Tests**: Tests template installations with npm, yarn, pnpm, and bun
+- **Package Manager Tests**: Tests template installations with npm and bun
 - **Automated Releases**: Publishes to npm on version tags
 
 ## Contributing

--- a/cli/__tests__/cli.e2e.test.ts
+++ b/cli/__tests__/cli.e2e.test.ts
@@ -132,7 +132,7 @@ describe('cli E2E tests', () => {
     expect(packageJson.name).toBe(projectName)
 
     // Verify essential files exist (Next.js App Router structure)
-    const essentialFiles = ['app/page.tsx', 'app/layout.tsx', 'next.config.js', 'package.json', 'tsconfig.json']
+    const essentialFiles = ['app/page.tsx', 'app/layout.tsx', 'next.config.mjs', 'package.json', 'tsconfig.json']
     for (const file of essentialFiles) {
       const filePath = path.join(projectPath, file)
       const fileExists = await fs.access(filePath).then(() => true).catch(() => false)
@@ -213,8 +213,8 @@ describe('cli E2E tests', () => {
     expect(packageJson.name).toBe(projectName)
 
     // Verify it's a Next.js project
-    const nextConfigExists = await fs.access(path.join(projectPath, 'next.config.js')).then(() => true).catch(() => false)
-    expect(nextConfigExists, 'Should create Next.js project with next.config.js').toBe(true)
+    const nextConfigExists = await fs.access(path.join(projectPath, 'next.config.mjs')).then(() => true).catch(() => false)
+    expect(nextConfigExists, 'Should create Next.js project with next.config.mjs').toBe(true)
   })
 
   it('handles invalid --template parameter correctly', async () => {
@@ -386,7 +386,7 @@ describe('cli E2E tests', () => {
     expect(packageJson.name).toBe(projectName)
 
     // Verify it's a Next.js project
-    const nextConfigExists = await fs.access(path.join(projectPath, 'next.config.js')).then(() => true).catch(() => false)
-    expect(nextConfigExists, 'Should create Next.js project with next.config.js').toBe(true)
+    const nextConfigExists = await fs.access(path.join(projectPath, 'next.config.mjs')).then(() => true).catch(() => false)
+    expect(nextConfigExists, 'Should create Next.js project with next.config.mjs').toBe(true)
   })
 })

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,17 +3,20 @@ import path from 'node:path'
 import process from 'node:process'
 import {
   cancel,
+  confirm,
   intro,
   isCancel,
   log,
   outro,
+  select,
   spinner,
   text,
 } from '@clack/prompts'
 import fs from 'fs-extra'
 import color from 'picocolors'
 import { downloadTemplate } from './downloader.js'
-import { pickTemplate } from './template-selector.js'
+import { detectPackageManager, installDependencies, packageManagers } from './package-manager.js'
+import { pickTemplate, templateOptions } from './template-selector.js'
 
 interface CliArgs {
   projectName?: string
@@ -68,7 +71,7 @@ ${color.bold('Options:')}
   -v, --version              Show version number
 
 ${color.bold('Available Templates:')}
-  next  ${color.dim('Next.js (Web3Auth + Wagmi)')}
+${templateOptions.map(option => `  ${option.value}  ${color.dim(option.label)}`).join('\n')}
 
 ${color.bold('Examples:')}
   ${color.dim('# Interactive mode')}
@@ -86,6 +89,10 @@ ${color.bold('Examples:')}
 ${color.bold('Learn more:')}
   ${color.underline('https://github.com/preschian/create-dot-app')}
 `)
+}
+
+function isInteractive(): boolean {
+  return Boolean(process.stdout.isTTY) && !process.env.CI
 }
 
 async function getVersion(): Promise<string> {
@@ -166,13 +173,55 @@ async function main() {
       await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 })
     }
 
+    // Copy .env.example to .env.local so the project works out of the box
+    const envExamplePath = path.join(targetPath, '.env.example')
+    if (await fs.pathExists(envExamplePath)) {
+      await fs.copy(envExamplePath, path.join(targetPath, '.env.local'))
+    }
+
     s.stop('Project created successfully!')
 
-    log.info(`${color.green('✓')} Done! Next steps:
-    ${color.cyan(`cd ${name}`)}
-    ${color.cyan('npm install')} ${color.dim('(or yarn install / pnpm install / bun install / deno install)')}
-    ${color.cyan('npm run dev')} ${color.dim('(or yarn dev / pnpm dev / bun dev / deno task dev)')}
-    `)
+    // Let the developer pick a package manager and optionally install now.
+    // Skip prompting in non-interactive contexts (CI, piped stdin).
+    let pm = detectPackageManager()
+    let installed = false
+
+    if (isInteractive()) {
+      const pmChoice = await select({
+        message: 'Which package manager do you want to use?',
+        options: packageManagers.map(value => ({ value, label: value })),
+        initialValue: pm,
+      })
+
+      if (!isCancel(pmChoice)) {
+        pm = pmChoice
+
+        const shouldInstall = await confirm({
+          message: `Install dependencies with ${color.cyan(pm)} now?`,
+          initialValue: true,
+        })
+
+        if (!isCancel(shouldInstall) && shouldInstall) {
+          try {
+            log.step(`Installing dependencies with ${pm}...`)
+            await installDependencies(pm, targetPath)
+            installed = true
+          }
+          catch (installError) {
+            log.warn(`Could not install dependencies: ${installError}\n    Run "${pm} install" manually once you're in the project.`)
+          }
+        }
+      }
+    }
+
+    // Build the next-steps list, skipping install if we already ran it
+    const steps = [color.cyan(`cd ${name}`)]
+    if (!installed) {
+      steps.push(color.cyan(`${pm} install`))
+    }
+    steps.push(color.cyan(`${pm} run dev`))
+
+    log.info(`${color.green('✓')} Done! Next steps:\n    ${steps.join('\n    ')}\n    `)
 
     outro('Happy coding!')
   }

--- a/cli/src/package-manager.ts
+++ b/cli/src/package-manager.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process'
+import process from 'node:process'
+
+export const packageManagers = ['npm', 'yarn', 'pnpm', 'bun'] as const
+export type PackageManager = typeof packageManagers[number]
+
+/**
+ * Detects the package manager used to invoke the CLI via npm_config_user_agent.
+ * Falls back to 'npm' when it can't be determined.
+ */
+export function detectPackageManager(): PackageManager {
+  const userAgent = process.env.npm_config_user_agent ?? ''
+  const name = userAgent.split(' ')[0]?.split('/')[0]
+
+  if ((packageManagers as readonly string[]).includes(name)) {
+    return name as PackageManager
+  }
+
+  return 'npm'
+}
+
+/**
+ * Runs `<pm> install` in the given directory, streaming output to the user.
+ * Rejects when the install exits with a non-zero code.
+ */
+export function installDependencies(pm: PackageManager, cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(pm, ['install'], {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      }
+      else {
+        reject(new Error(`${pm} install exited with code ${code}`))
+      }
+    })
+  })
+}

--- a/cli/src/package-manager.ts
+++ b/cli/src/package-manager.ts
@@ -1,16 +1,15 @@
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 
-// Only npm and bun are offered for now. The template declares its Hardhat
-// setup via the package.json "workspaces" field, which pnpm and yarn don't
-// honor the same way (pnpm needs a pnpm-workspace.yaml), so installs break.
-// Re-add them here once the template supports their workspace configs.
-export const packageManagers = ['npm', 'bun'] as const
+// Package managers offered by the CLI. The Next.js template supports all four:
+// npm, bun, and yarn read the package.json "workspaces" field, while pnpm reads
+// the pnpm-workspace.yaml shipped alongside it.
+export const packageManagers = ['npm', 'yarn', 'pnpm', 'bun'] as const
 export type PackageManager = typeof packageManagers[number]
 
 /**
  * Detects the package manager used to invoke the CLI via npm_config_user_agent.
- * Falls back to 'npm' for anything we don't support (e.g. pnpm, yarn).
+ * Falls back to 'npm' for anything we don't recognize.
  */
 export function detectPackageManager(): PackageManager {
   const userAgent = process.env.npm_config_user_agent ?? ''

--- a/cli/src/package-manager.ts
+++ b/cli/src/package-manager.ts
@@ -1,12 +1,16 @@
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 
-export const packageManagers = ['npm', 'yarn', 'pnpm', 'bun'] as const
+// Only npm and bun are offered for now. The template declares its Hardhat
+// setup via the package.json "workspaces" field, which pnpm and yarn don't
+// honor the same way (pnpm needs a pnpm-workspace.yaml), so installs break.
+// Re-add them here once the template supports their workspace configs.
+export const packageManagers = ['npm', 'bun'] as const
 export type PackageManager = typeof packageManagers[number]
 
 /**
  * Detects the package manager used to invoke the CLI via npm_config_user_agent.
- * Falls back to 'npm' when it can't be determined.
+ * Falls back to 'npm' for anything we don't support (e.g. pnpm, yarn).
  */
 export function detectPackageManager(): PackageManager {
   const userAgent = process.env.npm_config_user_agent ?? ''

--- a/templates/next/.gitignore
+++ b/templates/next/.gitignore
@@ -3,7 +3,15 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
+.pnp.*
+
+# yarn berry (node-modules linker still writes these)
+.yarn/*
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
 
 # testing
 /coverage

--- a/templates/next/.yarnrc.yml
+++ b/templates/next/.yarnrc.yml
@@ -1,0 +1,5 @@
+# Yarn Berry (v2+) defaults to Plug'n'Play, which Next.js 16's build hook can't
+# load (require.extensions is undefined under PnP's ESM loader). Use the classic
+# node_modules layout so the template builds the same way it does on npm/bun/pnpm.
+# Yarn Classic (v1) ignores this file and already defaults to node_modules.
+nodeLinker: node-modules

--- a/templates/next/components/welcome/panels/WritePanel.tsx
+++ b/templates/next/components/welcome/panels/WritePanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { waitForTransactionReceipt } from "@wagmi/core";
+import { waitForTransactionReceipt } from "wagmi/actions";
 import {
   useChains,
   useConfig,

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -20,6 +20,7 @@
     "next": "16.2.7",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "viem": "^2.52.0",
     "wagmi": "^3.6.16"
   },
   "devDependencies": {

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -10,9 +10,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "compile:contracts": "npm run compile -w hardhat",
-    "test:contracts": "npm run test -w hardhat",
-    "deploy:contracts": "npm run deploy -w hardhat"
+    "compile:contracts": "cd contracts && npm run compile",
+    "test:contracts": "cd contracts && npm run test",
+    "deploy:contracts": "cd contracts && npm run deploy"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.14",

--- a/templates/next/pnpm-workspace.yaml
+++ b/templates/next/pnpm-workspace.yaml
@@ -1,0 +1,26 @@
+# pnpm ignores the package.json "workspaces" field (used by npm/bun/yarn) and
+# reads its workspace layout from here instead. Keep this list in sync with it.
+packages:
+  - contracts
+
+# pnpm gates dependency build scripts (native addons and postinstall steps)
+# behind an allow-list, so a fresh install would otherwise stop and ask before
+# running them. npm, bun, and yarn run these by default; approving them here
+# keeps `pnpm install` non-interactive. `allowBuilds` is the pnpm v11+ form and
+# `onlyBuiltDependencies` is the v10 form, so both are listed to cover either.
+allowBuilds:
+  bufferutil: true
+  keccak: true
+  secp256k1: true
+  sharp: true
+  tiny-secp256k1: true
+  unrs-resolver: true
+  utf-8-validate: true
+onlyBuiltDependencies:
+  - bufferutil
+  - keccak
+  - secp256k1
+  - sharp
+  - tiny-secp256k1
+  - unrs-resolver
+  - utf-8-validate


### PR DESCRIPTION
## What

CLI post-scaffold DX improvements, a template build fix for non-npm package managers, and full cross-package-manager support (npm, yarn, pnpm, bun).

### CLI
- **Scaffold `.env.local`** — after the template is generated, copy `.env.example` → `.env.local` so the project runs out of the box.
- **Package manager selection + optional install** — after creation, prompt the developer to pick a package manager and offer to install dependencies right away (new helper [`cli/src/package-manager.ts`](cli/src/package-manager.ts)). Defaults to the manager detected via `npm_config_user_agent`. A failed install warns instead of aborting.
- **Offer npm, yarn, pnpm, and bun**: the picker lists all four and detection falls back to npm for anything unrecognized. The scheduled package-managers CI matrix runs all four (adding a `pnpm/action-setup` step), and the READMEs list npm/yarn/pnpm/bun (no `deno`). The workspace config that makes pnpm and yarn work lives in the Template section below.
- **Drop Deno hints** and **generate the help text's template list** from `templateOptions` (single source of truth).

### Template
- **Fix phantom dependencies that broke bun/pnpm installs** — the Next.js template imported packages it never declared, relying on npm hoisting transitive/peer deps:
  - Import `waitForTransactionReceipt` from `wagmi/actions` instead of `@wagmi/core` (re-exports the same action from the instance wagmi already uses; bun nests `@wagmi/core` under `wagmi` rather than hoisting it).
  - Declare `viem` as a direct dependency (peer dep of wagmi; npm auto-installs peers, bun does not). Pinned `^2.52.0` to satisfy wagmi `2.x` and `@web3auth/modal` `>=2.23`.
- **Cross-package-manager workspace config** so the Hardhat workspace and native build scripts resolve under every manager:
  - `pnpm-workspace.yaml` declares the `contracts` workspace (pnpm ignores `package.json#workspaces`) and allow-lists the native build scripts pnpm gates (`sharp`, `keccak`, `secp256k1`, `bufferutil`, `utf-8-validate`, `tiny-secp256k1`, `unrs-resolver`) via `allowBuilds` (pnpm v11) and `onlyBuiltDependencies` (pnpm v10).
  - `.yarnrc.yml` sets `nodeLinker: node-modules` so Yarn Berry skips Plug'n'Play, which Next 16's build hook can't load (`require.extensions` is undefined under PnP's ESM loader). Yarn Classic ignores the file and already uses node_modules.
  - Contract helper scripts are now `cd contracts && npm run <task>` instead of the npm-only `npm run <task> -w hardhat`.
  - `.gitignore` covers Yarn Berry's `.yarn/cache`.

### Tests
- Fix e2e assertions that referenced `next.config.js`; the template ships `next.config.mjs`.

## Reviewer notes
- The package-manager prompt/install is **skipped in non-interactive contexts** (CI or piped stdin) via an `isInteractive()` guard, so the e2e suite (run with `CI=true`) never hangs. Adding pnpm/yarn to the picker does not change this.
- Verified `bun install && bun run build` on the template now compiles cleanly (it failed with "Module not found: @wagmi/core" before).
- pnpm 11.5.1 records build-script approvals under `allowBuilds`; `onlyBuiltDependencies` is kept alongside for pnpm 10, so a fresh install never stops to prompt on either major.

## Verification
- CLI: `bun run lint` clean, `bun run build` passes, `bun run test` 13/13 e2e pass.
- Template, on a clean tracked-files-only checkout (`install` + `run lint` + `run build` all green):
  - npm and bun
  - pnpm 11.5.1
  - yarn Berry 3.2.3 and yarn Classic 1.22.22 (CI parity)
- `pnpm run compile:contracts` compiles the Hardhat workspace end-to-end (verifies the cross-PM contract scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
