### PR TITLE
feat(next-papi): use smoldot light client and bump deps to latest

### DIFF
--- a/templates/next-papi/README.md
+++ b/templates/next-papi/README.md
@@ -1,13 +1,14 @@
 # Next.js PAPI Template
 
-A modern **Next.js 15 + TypeScript + React 19** template for building Polkadot decentralized applications (dApps) using the PAPI SDK.
+A modern **Next.js 16 + TypeScript + React 19** template for building Polkadot decentralized applications (dApps) using the PAPI SDK.
 
 ## 🚀 Features
 
-- **Next.js 15** with App Router and Turbopack
+- **Next.js 16** with App Router and Turbopack
 - **React 19** for modern UI development
 - **TypeScript** for type safety
 - **PAPI SDK** integration for Polkadot blockchain interaction
+- **Light client** connectivity via smoldot — verifies the chain in-browser instead of trusting a single RPC node
 - **TailwindCSS 4 + DaisyUI** for beautiful UI components
 - **Wallet Connection** support via Talisman Connect
 - **Iconify** icons integration
@@ -19,8 +20,12 @@ This template uses **PAPI (Polkadot API)** - a modern, type-safe SDK for interac
 
 📚 **PAPI Documentation**: https://papi.how/
 
+### Connectivity
+
+Chains connect through an in-browser **smoldot light client** (`getSmProvider`) rather than a remote RPC node, so the app verifies blocks itself instead of trusting a single endpoint. smoldot runs in a Web Worker, and each chain's spec is loaded on demand via a dynamic import. The first connection to a chain warp-syncs and can take a few seconds; the asset hubs are parachains, so they also sync their relay chain (`dot` / `pas`) under the hood.
+
 ### Configuration Files:
-- **`app/utils/sdk.ts`** - Configures which chains to connect to and manages chain endpoints. You can modify supported networks and RPC providers here.
+- **`app/utils/sdk.ts`** - Configures which chains to connect to. Each chain runs through the smoldot light client; edit this file to add or remove supported networks (or switch a chain back to a remote RPC endpoint).
 - **`app/utils/sdk-interface.ts`** - Provides high-level functions for onchain SDK calls.
 
 ## 🌐 Supported Chains
@@ -76,37 +81,35 @@ npx papi add kusama -n ksmcc3
 npx papi
 ```
 
-This creates type-safe descriptors in `@polkadot-api/descriptors` that you can import.
+This generates type-safe descriptors into the local `app/descriptors` folder (the template sets `noDescriptorsPackage` in `.papi/polkadot-api.json`), which you import via `../descriptors` (see `app/utils/sdk.ts`).
 
 ### Step 2: Configure Your Chain
 
-Edit `app/utils/sdk.ts` to add your chain configuration:
+Edit `app/utils/sdk.ts` to add your chain configuration. Each chain points to a light-client chain spec, loaded lazily with a dynamic import:
 
 ```typescript
-import { yourChain } from '@polkadot-api/descriptors'
+import { yourChain } from '../descriptors'
 
-const CONFIG = {
+const config = {
   // ... existing chains
   your_chain: {
     descriptor: yourChain,
-    providers: ['wss://your-rpc-endpoint.io'],
+    chainSpec: () => import('polkadot-api/chains/your_chain'),
   },
 }
 ```
 
-You can add multiple RPC endpoints for fallback support:
+For a **parachain**, add the relay it syncs against (a relay-chain key already defined in `config`):
 
 ```typescript
-const CONFIG = {
-  dot: {
-    descriptor: polkadot,
-    providers: [
-      'wss://rpc.polkadot.io',
-      'wss://polkadot-rpc.dwellir.com'
-    ],
-  },
-}
+your_parachain: {
+  descriptor: yourParachain,
+  chainSpec: () => import('polkadot-api/chains/your_parachain'),
+  relay: 'dot',
+},
 ```
+
+`polkadot-api/chains/*` bundles specs for the well-known relay and system chains. If PAPI does not bundle a spec for your chain, supply your own chain-spec string, or connect over RPC instead with `getWsProvider('wss://your-rpc-endpoint.io')` from `polkadot-api/ws-provider`.
 
 📖 For more details, see the [PAPI Codegen documentation](https://papi.how/codegen).
 

--- a/templates/next-papi/app/hooks/use-connect.ts
+++ b/templates/next-papi/app/hooks/use-connect.ts
@@ -4,7 +4,7 @@ import type { Wallet, WalletAccount } from '@talismn/connect-wallets'
 import type { Atom } from '@xstate/store'
 import { getWallets } from '@talismn/connect-wallets'
 import { createAtom } from '@xstate/store'
-import { useAtom } from '@xstate/store/react'
+import { useSelector } from '@xstate/store-react'
 import { useEffect, useState } from 'react'
 import { DAPP_NAME } from '../utils/sdk-interface'
 
@@ -104,10 +104,10 @@ export function useConnect() {
 
   return {
     // State
-    listAccounts: useAtom(listAccounts),
-    selectedAccount: useAtom(selectedAccount),
-    connectedWallet: useAtom(connectedWallet),
-    isConnecting: useAtom(isConnecting),
+    listAccounts: useSelector(listAccounts),
+    selectedAccount: useSelector(selectedAccount),
+    connectedWallet: useSelector(connectedWallet),
+    isConnecting: useSelector(isConnecting),
     wallets,
     installedWallets,
     availableWallets,

--- a/templates/next-papi/app/utils/sdk.ts
+++ b/templates/next-papi/app/utils/sdk.ts
@@ -1,31 +1,84 @@
 import type { PolkadotClient, TypedApi } from 'polkadot-api'
 import { createAtom } from '@xstate/store'
 import { createClient } from 'polkadot-api'
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat'
-import { getWsProvider } from 'polkadot-api/ws-provider'
+import { getSmProvider } from 'polkadot-api/sm-provider'
+import { startFromWorker } from 'polkadot-api/smoldot/from-worker'
 import { dot, dot_asset_hub, pas, pas_asset_hub } from '../descriptors'
 
+// Each chain connects through an in-browser smoldot light client instead of a
+// remote RPC node, so the app verifies the chain itself rather than trusting a
+// single endpoint. `chainSpec` is loaded with a dynamic import so the (large)
+// spec JSON is only downloaded when that chain is actually used. Parachains (the
+// asset hubs) declare the relay they sync against via `potentialRelayChains`.
+//
+// Prefer a remote RPC instead? Swap the provider in `sdk()` below for
+// `getWsProvider('wss://...')` (from 'polkadot-api/ws-provider') and drop the
+// `chainSpec`/smoldot wiring.
 const config = {
   dot: {
     descriptor: dot,
-    providers: ['wss://dot-rpc.stakeworld.io'],
+    chainSpec: () => import('polkadot-api/chains/polkadot'),
   },
   dot_asset_hub: {
     descriptor: dot_asset_hub,
-    providers: ['wss://dot-rpc.stakeworld.io/assethub'],
+    chainSpec: () => import('polkadot-api/chains/polkadot_asset_hub'),
+    relay: 'dot',
   },
   pas: {
     descriptor: pas,
-    providers: ['wss://pas-rpc.stakeworld.io'],
+    chainSpec: () => import('polkadot-api/chains/paseo'),
   },
   pas_asset_hub: {
     descriptor: pas_asset_hub,
-    providers: ['wss://pas-rpc.stakeworld.io/assethub'],
+    chainSpec: () => import('polkadot-api/chains/paseo_asset_hub'),
+    relay: 'pas',
   },
 } as const
 
 export type Prefix = keyof typeof config
 export const chainKeys = Object.keys(config) as Prefix[]
+
+type Smoldot = ReturnType<typeof startFromWorker>
+type SmoldotChain = Awaited<ReturnType<Smoldot['addChain']>>
+
+// One smoldot instance (running in a Web Worker, off the main thread) is shared
+// by every chain. Created lazily so it never runs during SSR — `sdk()` is only
+// ever called from client-side effects and event handlers.
+let smoldot: Smoldot | undefined
+
+function getSmoldot() {
+  if (!smoldot) {
+    smoldot = startFromWorker(
+      new Worker(new URL('polkadot-api/smoldot/worker', import.meta.url)),
+    )
+  }
+
+  return smoldot
+}
+
+// Cache the smoldot chain per prefix so a relay chain (e.g. `dot`) is synced
+// once and reused both as its own chain and as the relay for its asset hub.
+const chainStore: Partial<Record<Prefix, Promise<SmoldotChain>>> = {}
+
+function getChain(chain: Prefix): Promise<SmoldotChain> {
+  if (!chainStore[chain]) {
+    chainStore[chain] = (async () => {
+      const entry = config[chain]
+      const { chainSpec } = await entry.chainSpec()
+
+      if ('relay' in entry) {
+        return getSmoldot().addChain({
+          chainSpec,
+          potentialRelayChains: [await getChain(entry.relay)],
+        })
+      }
+
+      return getSmoldot().addChain({ chainSpec })
+    })()
+  }
+
+  return chainStore[chain]!
+}
 
 const clientStore = createAtom<Partial<Record<Prefix, PolkadotClient>>>({})
 
@@ -33,11 +86,7 @@ export default function sdk<T extends Prefix>(chain: T) {
   const clients = clientStore.get()
 
   if (!clients[chain]) {
-    clients[chain] = createClient(
-      withPolkadotSdkCompat(
-        getWsProvider(config[chain].providers[0]),
-      ),
-    )
+    clients[chain] = createClient(getSmProvider(() => getChain(chain)))
   }
 
   return {

--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -10,28 +10,29 @@
     "postinstall": "papi"
   },
   "dependencies": {
-    "@polkadot-api/react-components": "^0.4.1",
+    "@polkadot-api/react-components": "^0.4.2",
     "@talismn/connect-wallets": "^1.2.8",
-    "@xstate/store": "^3.13.0",
-    "next": "16.1.5",
-    "polkadot-api": "^1.23.1",
-    "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "@xstate/store": "^4.1.0",
+    "@xstate/store-react": "^2.0.0",
+    "next": "16.2.7",
+    "polkadot-api": "^2.1.5",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@iconify-json/mdi": "^1.2.3",
-    "@iconify-json/token-branded": "^1.2.34",
-    "@iconify/tailwind4": "^1.2.0",
-    "@next/eslint-plugin-next": "^16.0.10",
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^25",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "daisyui": "^5.5.14",
-    "eslint": "^9.39.2",
-    "eslint-config-next": "^16.0.10",
-    "tailwindcss": "^4",
-    "typescript": "^5"
+    "@iconify-json/token-branded": "^1.2.40",
+    "@iconify/tailwind4": "^1.2.3",
+    "@next/eslint-plugin-next": "^16.2.7",
+    "@tailwindcss/postcss": "^4.3.0",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
+    "daisyui": "^5.5.20",
+    "eslint": "^9.39.4",
+    "eslint-config-next": "^16.2.7",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^6.0.3"
   },
   "browserslist": "> 1%"
 }


### PR DESCRIPTION
## Summary

Convert the `next-papi` template from WebSocket RPC to an in-browser smoldot light client (`getSmProvider`) so the app verifies chains itself instead of trusting a single RPC endpoint, with relay chains synced once and reused for their asset hubs and smoldot running in a Web Worker. Bump all dependencies to latest: `polkadot-api` 2 (now uses the `getSmProvider` function form) and `@xstate/store` 4 (drops the `/react` subpath, so `@xstate/store-react` was added and `useAtom` migrated to `useSelector`), while ESLint stays on the latest 9.x because ESLint 10 breaks `eslint-config-next`'s bundled `eslint-plugin-react`. The README is updated for the light client, Next.js 16, and the local `app/descriptors` setup. Verified with a clean install, lint, and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
