### PR TITLE
feat(cli): choose Solidity (next) or Substrate (next-papi) when scaffolding

### DIFF
--- a/.changeset/cli-solidity-substrate-choice.md
+++ b/.changeset/cli-solidity-substrate-choice.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": minor
+---
+
+feat(cli): let users choose Solidity (next) or Substrate (next-papi) when scaffolding

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,11 +4,19 @@ A command-line interface (CLI) tool designed to streamline the development proce
 
 ## Features
 
-### ⚡ Next.js + Web3Auth Template
+Choose the Polkadot stack you want to build with:
+
+### ⚡ Solidity — `next`
 - **Next.js** (App Router) with React 19 and Tailwind CSS
 - **[Web3Auth](https://web3auth.io/)** social/embedded wallet login
 - **[Wagmi](https://wagmi.sh/)** for EVM wallet and contract interactions
-- **Solidity** smart contracts via an integrated Hardhat workspace (Polkadot Hub)
+- **Solidity** smart contracts on Polkadot Hub (EVM)
+
+### 🟣 Substrate — `next-papi`
+- **Next.js** (App Router) with React 19 and Tailwind CSS
+- **[PAPI](https://papi.how/)** (polkadot-api) for native Polkadot interaction
+- **[smoldot](https://github.com/smol-dot/smoldot)** light client transport
+- Connect Wallet plus a sample `system.remark` extrinsic, wired out of the box
 
 ### 📦 Package Manager Support
 Compatible with npm, yarn, pnpm, and bun
@@ -30,21 +38,21 @@ Create a new Polkadot dApp project with interactive prompts:
 npx create-dot-app@latest
 ```
 
-Enter your project name when prompted. The Next.js template is currently selected automatically.
+Enter your project name when prompted, then pick a stack: **Solidity** (`next`) or **Substrate** (`next-papi`).
 
 ### Non-Interactive Mode
 
 Skip the prompts by providing options via CLI flags:
 
 ```bash
-# Specify project name only
+# Specify project name only (defaults to the next template)
 npx create-dot-app@latest my-dapp
 
-# Specify project name and template
+# Solidity dapp (Polkadot Hub EVM)
 npx create-dot-app@latest my-dapp --template next
 
-# Full non-interactive mode
-npx create-dot-app@latest my-dapp -t next
+# Substrate dapp (Polkadot native)
+npx create-dot-app@latest my-dapp --template next-papi
 ```
 
 ### CLI Options
@@ -58,16 +66,18 @@ npx create-dot-app@latest my-dapp -t next
 
 #### Available Templates
 
-- `next` - Next.js (Web3Auth + Wagmi)
+- `next` - Solidity (Next.js + Web3Auth + Wagmi, Polkadot Hub EVM)
+- `next-papi` - Substrate (Next.js + PAPI light client, Polkadot native)
 
 ## Quick Start
 
 ```bash
-# Interactive mode
+# Interactive mode (pick Solidity or Substrate)
 npx create-dot-app@latest
 
-# Non-interactive with specific template
-npx create-dot-app@latest my-dapp --template next
+# Non-interactive with a specific template
+npx create-dot-app@latest my-dapp --template next        # Solidity
+npx create-dot-app@latest my-dapp --template next-papi   # Substrate
 
 # Navigate to project directory
 cd my-dapp

--- a/cli/__tests__/cli.e2e.test.ts
+++ b/cli/__tests__/cli.e2e.test.ts
@@ -112,7 +112,8 @@ describe('cli E2E tests', () => {
     const projectName = 'test-project-arg'
     const projectPath = path.join(testDir, projectName)
 
-    // Only the Next.js template is available, so no template prompt appears.
+    // spawnCLI sets CI=1, so the run is non-interactive: no template prompt
+    // appears and the default (next) template is used.
     const { output } = await spawnCLI(testDir, {
       args: [projectName],
       timeout: 60000,
@@ -146,7 +147,7 @@ describe('cli E2E tests', () => {
 
     let askedForName = false
 
-    // The only interactive prompt is the project name; the template is auto-selected.
+    // Under CI=1 the only prompt is the project name; the template defaults to next.
     const { output } = await spawnCLI(testDir, {
       args: [],
       onData: async (_, cleanOutput, process) => {
@@ -217,6 +218,40 @@ describe('cli E2E tests', () => {
     expect(nextConfigExists, 'Should create Next.js project with next.config.mjs').toBe(true)
   })
 
+  it('creates Substrate project with --template=next-papi', async () => {
+    const projectName = 'substrate-param-test'
+    const projectPath = path.join(testDir, projectName)
+
+    const { output } = await spawnCLI(testDir, {
+      args: [projectName, '--template=next-papi'],
+      timeout: 60000,
+    })
+
+    // Verify output contains expected messages
+    expect(output).toContain('create-dot-app')
+    expect(output).toContain(`Using project name: ${projectName}`)
+    expect(output).toContain('Using template: next-papi')
+    expect(output).toContain('Project created successfully!')
+
+    // Verify project directory was created
+    const projectExists = await fs.access(projectPath).then(() => true).catch(() => false)
+    expect(projectExists).toBe(true)
+
+    // Verify package.json has correct name
+    const packageJsonPath = path.join(projectPath, 'package.json')
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
+    expect(packageJson.name).toBe(projectName)
+
+    // Verify it's the PAPI (Substrate) template: ships next.config.ts and PAPI descriptors,
+    // which distinguish it from the Solidity `next` template (next.config.mjs, no .papi)
+    const papiMarkers = ['app/page.tsx', 'next.config.ts', '.papi']
+    for (const file of papiMarkers) {
+      const filePath = path.join(projectPath, file)
+      const fileExists = await fs.access(filePath).then(() => true).catch(() => false)
+      expect(fileExists, `File ${file} should exist`).toBe(true)
+    }
+  })
+
   it('handles invalid --template parameter correctly', async () => {
     const projectName = 'invalid-template-test'
 
@@ -226,10 +261,11 @@ describe('cli E2E tests', () => {
       timeout: 30000,
     })
 
-    // Should contain error message about invalid template, listing the available one
+    // Should contain error message about invalid template, listing the available ones
     expect(output).toContain('Invalid template "invalid-template"')
     expect(output).toContain('Available templates:')
     expect(output).toContain('next')
+    expect(output).toContain('next-papi')
   })
 
   it('creates project with --template parameter only (prompts for name)', async () => {

--- a/cli/__tests__/template-selector.test.ts
+++ b/cli/__tests__/template-selector.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the clack prompts the selector depends on so we can drive the
+// interactive branch without a real TTY.
+const { selectMock, cancelMock, isCancelMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  cancelMock: vi.fn(),
+  isCancelMock: vi.fn(() => false),
+}))
+
+vi.mock('@clack/prompts', () => ({
+  select: selectMock,
+  cancel: cancelMock,
+  isCancel: isCancelMock,
+}))
+
+const { pickTemplate, templateOptions } = await import('../src/template-selector.ts')
+
+describe('template selector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isCancelMock.mockReturnValue(false)
+  })
+
+  it('offers Solidity (next) and Substrate (next-papi) options', () => {
+    const byValue = Object.fromEntries(templateOptions.map(o => [o.value, o.label]))
+    expect(byValue.next).toBe('Solidity')
+    expect(byValue['next-papi']).toBe('Substrate')
+  })
+
+  it('returns the chosen template in interactive mode', async () => {
+    selectMock.mockResolvedValue('next-papi')
+
+    const result = await pickTemplate(undefined, true)
+
+    expect(result).toBe('next-papi')
+    expect(selectMock).toHaveBeenCalledTimes(1)
+    const call = selectMock.mock.calls[0][0]
+    expect(call.options).toBe(templateOptions)
+    expect(call.message.toLowerCase()).toContain('stack')
+  })
+
+  it('falls back to the default template (next) when non-interactive', async () => {
+    const result = await pickTemplate(undefined, false)
+
+    expect(result).toBe('next')
+    expect(selectMock).not.toHaveBeenCalled()
+  })
+
+  it('honors a valid provided template without prompting', async () => {
+    expect(await pickTemplate('next-papi')).toBe('next-papi')
+    expect(await pickTemplate('next')).toBe('next')
+    expect(selectMock).not.toHaveBeenCalled()
+  })
+})

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -71,20 +71,20 @@ ${color.bold('Options:')}
   -v, --version              Show version number
 
 ${color.bold('Available Templates:')}
-${templateOptions.map(option => `  ${option.value}  ${color.dim(option.label)}`).join('\n')}
+${templateOptions.map(option => `  ${color.cyan(String(option.value).padEnd(10))} ${option.label}${option.hint ? color.dim(` (${option.hint})`) : ''}`).join('\n')}
 
 ${color.bold('Examples:')}
-  ${color.dim('# Interactive mode')}
+  ${color.dim('# Interactive mode (pick Solidity or Substrate)')}
   npx create-dot-app@latest
 
   ${color.dim('# Specify project name')}
   npx create-dot-app@latest my-dapp
 
-  ${color.dim('# Specify project name and template')}
+  ${color.dim('# Solidity dapp (Polkadot Hub EVM)')}
   npx create-dot-app@latest my-dapp --template next
 
-  ${color.dim('# Full non-interactive mode')}
-  npx create-dot-app@latest my-dapp -t next
+  ${color.dim('# Substrate dapp (Polkadot native)')}
+  npx create-dot-app@latest my-dapp --template next-papi
 
 ${color.bold('Learn more:')}
   ${color.underline('https://github.com/preschian/create-dot-app')}
@@ -145,8 +145,8 @@ async function main() {
     name = nameInput
   }
 
-  // Resolve the template (only the Next.js template is currently available)
-  const template = await pickTemplate(args.template)
+  // Resolve the template: honor --template, otherwise prompt (Solidity vs Substrate)
+  const template = await pickTemplate(args.template, isInteractive())
   log.info(`Using template: ${template}`)
 
   const s = spinner()

--- a/cli/src/template-selector.ts
+++ b/cli/src/template-selector.ts
@@ -1,22 +1,51 @@
 import type { SelectOptions } from '@clack/prompts'
 import process from 'node:process'
-import { cancel } from '@clack/prompts'
+import { cancel, isCancel, select } from '@clack/prompts'
 
 const DEFAULT_TEMPLATE = 'next'
 
 export const templateOptions: SelectOptions<string>['options'] = [
-  { value: DEFAULT_TEMPLATE, label: 'Next.js (Web3Auth + Wagmi)' },
+  {
+    value: 'next',
+    label: 'Solidity',
+    hint: 'Next.js + Web3Auth + Wagmi, Polkadot Hub EVM',
+  },
+  {
+    value: 'next-papi',
+    label: 'Substrate',
+    hint: 'Next.js + PAPI light client, Polkadot native',
+  },
 ]
 
-export async function pickTemplate(providedTemplate?: string): Promise<string> {
+export async function pickTemplate(providedTemplate?: string, interactive = true): Promise<string> {
   const validTemplates = templateOptions.map(option => option.value)
 
   // Validate the provided template if one was passed
-  if (providedTemplate && !validTemplates.includes(providedTemplate)) {
-    cancel(`Invalid template "${providedTemplate}". Available templates: ${validTemplates.join(', ')}`)
-    process.exit(1)
+  if (providedTemplate) {
+    if (!validTemplates.includes(providedTemplate)) {
+      cancel(`Invalid template "${providedTemplate}". Available templates: ${validTemplates.join(', ')}`)
+      process.exit(1)
+    }
+
+    return providedTemplate
   }
 
-  // Only the Next.js template is currently available, so use it directly
-  return providedTemplate ?? DEFAULT_TEMPLATE
+  // Non-interactive contexts (CI, piped stdin) can't prompt, so use the default
+  if (!interactive) {
+    return DEFAULT_TEMPLATE
+  }
+
+  // Let the developer choose which Polkadot stack to scaffold
+  const choice = await select({
+    message: 'Which Polkadot stack do you want to build with?',
+    options: templateOptions,
+    initialValue: DEFAULT_TEMPLATE,
+  })
+
+  if (isCancel(choice)) {
+    cancel('Operation cancelled')
+    process.exit(0)
+  }
+
+  return choice
 }

--- a/docs/src/components/landing/Stack.astro
+++ b/docs/src/components/landing/Stack.astro
@@ -1,5 +1,7 @@
 ---
-// The stack — five layers, UI down to the chain, with a foundation note.
+// The stack — five layers, UI down to the chain, with foundation notes.
+// The layers show the Solidity (next) track; a second note points to the
+// native Substrate (next-papi) alternative.
 import { STACK } from '../../data/landing';
 ---
 
@@ -31,5 +33,11 @@ import { STACK } from '../../data/landing';
       <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
     </svg>
     <span class="lp-foundation-text">settles onto <strong>Polkadot Hub</strong>: Passet testnet, mainnet or Kusama Hub</span>
+  </div>
+  <div class="lp-foundation">
+    <svg viewBox="0 0 24 24" fill="none" width="1em" height="1em" aria-hidden="true">
+      <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+    </svg>
+    <span class="lp-foundation-text">prefer native Substrate? the <strong>next-papi</strong> stack swaps wagmi and Hardhat for <strong>PAPI</strong> with a smoldot light client</span>
   </div>
 </section>

--- a/docs/src/data/landing.ts
+++ b/docs/src/data/landing.ts
@@ -14,19 +14,18 @@ export type ScaffoldKind = 'cmd' | 'q' | 'ok' | 'dim' | 'next';
 export const SCAFFOLD_LINES: { t: ScaffoldKind; s: string }[] = [
   { t: 'cmd', s: 'npm create dot-app@latest' },
   { t: 'q', s: '◇  Project name … my-dapp' },
-  { t: 'q', s: '◇  Network … Polkadot, Kusama, Paseo' },
-  { t: 'q', s: '◇  Template … Wallet + Contracts' },
+  { t: 'q', s: '◇  Stack … Solidity · Substrate' },
+  { t: 'q', s: '◇  Package manager … npm' },
   { t: 'ok', s: '◇  Scaffolding project' },
   { t: 'dim', s: '   created 38 files · pinned lockfile' },
   { t: 'ok', s: '◇  Done in 4.2s' },
   { t: 'next', s: '→  cd my-dapp' },
-  { t: 'next', s: '→  npm install' },
   { t: 'next', s: '→  npm run dev' },
 ];
 
 // Quickstart — the four commands.
 export const STEPS = [
-  { n: '01', cmd: 'npm create dot-app@latest', note: 'Scaffold a fresh project. Pick chains and a template in the prompt.' },
+  { n: '01', cmd: 'npm create dot-app@latest', note: 'Scaffold a fresh project. Pick your stack, Solidity or Substrate, in the prompt.' },
   { n: '02', cmd: 'cd my-dapp && npm i', note: 'Install dependencies. Lockfile pinned, zero post-install scripts.' },
   { n: '03', cmd: 'npm run dev', note: 'Boots a forked local node, seeds accounts, opens the app on :5173.' },
   { n: '04', cmd: 'npm run deploy', note: 'Type-checked, env-aware deploy to any configured network.' },


### PR DESCRIPTION
## What

The CLI now lets users pick a Polkadot stack when scaffolding, instead of silently using the only available template:

- **Solidity** → `next` template (Polkadot Hub EVM, Web3Auth + Wagmi)
- **Substrate** → `next-papi` template (Polkadot native, PAPI light client)

```
$ npx create-dot-app@latest
◇  What is your project name? … my-polkadot-app
◆  Which Polkadot stack do you want to build with?
│  ● Solidity (Next.js + Web3Auth + Wagmi, Polkadot Hub EVM)
│  ○ Substrate (Next.js + PAPI light client, Polkadot native)
```

## Why

Both paradigm tracks (EVM/Solidity and native/Substrate) already exist as templates; the scaffolder only ever offered `next`. This surfaces `next-papi` as a first-class choice so users can start on either stack from the prompt.

## How

- `pickTemplate` now exposes both options and shows an interactive `select`. It gains an `interactive` flag so CI / non-TTY runs fall back to the default (`next`) instead of hanging on the prompt.
- The `--template` flag still accepts the canonical template names (`next` / `next-papi`), so existing flags, scripts, and tests stay backward compatible. An invalid `--template` now lists both templates in the error.
- Refreshed `--help` (template list with hints + Solidity/Substrate examples) and the CLI README.

## Tests

- New E2E test scaffolding `--template=next-papi` (asserts `next.config.ts` + `.papi` markers that distinguish it from the `next` template).
- New unit tests for the selector: interactive choice, non-interactive default fallback, provided-template path, and option labels.
- Full CLI suite green: **18 passed** (14 E2E + 4 unit). Build + lint clean.

## Notes for reviewer

- Backward compatible — no breaking changes to the `--template` interface. Bumped as a `minor` via changeset.
- The interactive prompt only appears in a real TTY (skipped under `CI=1` / piped stdin), matching how the package-manager prompt already behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)