### PR TITLE
fix(templates): repair next-papi pnpm install and dedupe welcome hero name

### DIFF
--- a/templates/next-papi/app/components/app.tsx
+++ b/templates/next-papi/app/components/app.tsx
@@ -6,7 +6,7 @@
 // template's real polkadot-api + Talisman hooks (light client under the hood).
 import type { Prefix } from '../utils/sdk'
 import { useState } from 'react'
-import { FEATURES, HEADLINE, HERO_BLURB, PROJECT, RESOURCES } from './welcome/data'
+import { CLI, FEATURES, HEADLINE, HERO_BLURB, RESOURCES } from './welcome/data'
 import { DEFAULT_NETWORK, networkByKey } from './welcome/networks'
 import { ConnectModal } from './welcome/panels/ConnectModal'
 import { HeaderUtilities } from './welcome/panels/HeaderControls'
@@ -73,7 +73,7 @@ export default function App() {
             {HEADLINE}
           </h1>
           <p className="m-0 pb-2.5 text-[16.5px] leading-snug text-(--dim)">
-            <span className="font-medium text-(--ink)">{PROJECT}</span>
+            <span className="font-medium text-(--ink)">{CLI}</span>
             {' '}
             {HERO_BLURB}
           </p>

--- a/templates/next-papi/app/components/welcome/data.ts
+++ b/templates/next-papi/app/components/welcome/data.ts
@@ -1,7 +1,6 @@
 // Static content for the create-dot-app welcome screen — Polkadot-native (papi).
 
 export const CLI = 'create-dot-app'
-export const PROJECT = 'my-dapp'
 export const HEADLINE = 'Ship your dapp today.'
 
 export interface Feature {

--- a/templates/next-papi/pnpm-workspace.yaml
+++ b/templates/next-papi/pnpm-workspace.yaml
@@ -1,0 +1,19 @@
+# pnpm gates dependency build scripts (native addons and postinstall steps)
+# behind an allow-list. Without this file a fresh `pnpm install` silently skips
+# them, and the next `pnpm run build`/`dev` re-checks dependencies and hard-fails
+# with ERR_PNPM_IGNORED_BUILDS. npm, bun, and yarn run these by default;
+# approving them here keeps pnpm non-interactive and working too. `allowBuilds`
+# is the pnpm v11+ form and `onlyBuiltDependencies` is the v10 form, so both are
+# listed to cover either.
+allowBuilds:
+  bufferutil: true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  utf-8-validate: true
+onlyBuiltDependencies:
+  - bufferutil
+  - esbuild
+  - sharp
+  - unrs-resolver
+  - utf-8-validate

--- a/templates/next/components/App.tsx
+++ b/templates/next/components/App.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { useSwitchChain } from "wagmi";
 import { tokens, DEFAULT_ACCENT, themeVars } from "@/components/welcome/theme";
 import { NETWORKS, networkByChainId } from "@/components/welcome/networks";
-import { FEATURES, RESOURCES, PROJECT, HEADLINE, HERO_BLURB } from "@/components/welcome/data";
+import { FEATURES, RESOURCES, CLI, HEADLINE, HERO_BLURB } from "@/components/welcome/data";
 import { Ic } from "@/components/welcome/ui/icons";
 import { HeaderUtilities } from "@/components/welcome/panels/HeaderControls";
 import { NetworkSwitch } from "@/components/welcome/panels/NetworkSwitch";
@@ -81,7 +81,7 @@ export default function App() {
             {HEADLINE}
           </h1>
           <p className="m-0 pb-2.5 text-[16.5px] leading-snug text-(--dim)">
-            <span className="font-medium text-(--ink)">{PROJECT}</span> {HERO_BLURB}
+            <span className="font-medium text-(--ink)">{CLI}</span> {HERO_BLURB}
           </p>
         </section>
 

--- a/templates/next/components/welcome/data.ts
+++ b/templates/next/components/welcome/data.ts
@@ -1,7 +1,6 @@
 // Static content for the create-dot-app welcome screen — Polkadot-native.
 
 export const CLI = "create-dot-app";
-export const PROJECT = "my-dapp";
 export const HEADLINE = "Ship your dapp today.";
 
 export interface Feature {


### PR DESCRIPTION
## What

- **Fix pnpm on `next-papi`**: add `templates/next-papi/pnpm-workspace.yaml` with a build-script allow-list, so pnpm stops skipping the `esbuild`, `sharp`, and `unrs-resolver` native builds. Without it, `pnpm install` only warns, but the next `pnpm run build`/`dev` re-checks deps and hard-fails with `ERR_PNPM_IGNORED_BUILDS` before Next even starts.
- **Dedupe welcome hero name**: collapse the duplicate `CLI`/`PROJECT` constants in the `next` and `next-papi` welcome screens into a single `CLI` constant, so the hero reads "create-dot-app is a Polkadot..." instead of the leftover "my-dapp" placeholder.

## Verification

Scaffolded both templates fresh and ran `pnpm install` + `pnpm run build` + `pnpm run lint`: both compile successfully with zero lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
