### PR TITLE
feat(cli): add next-dedot stack (smoldot light client) + harden the dedot template

### DIFF
--- a/.changeset/cli-next-dedot-choice.md
+++ b/.changeset/cli-next-dedot-choice.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": minor
+---
+
+feat(cli): add the Substrate (Dedot) stack (next-dedot) as a scaffolding option

--- a/.changeset/next-dedot-bump-dedot-deps.md
+++ b/.changeset/next-dedot-bump-dedot-deps.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": patch
+---
+
+chore(next-dedot): bump dedot to ^1.3.0 and @dedot/chaintypes to ^0.280.0 (the prior ^0.214.0 caret could not reach the latest chaintypes)

--- a/.changeset/next-dedot-reconnect-registry.md
+++ b/.changeset/next-dedot-reconnect-registry.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": patch
+---
+
+fix(next-dedot): wait for the dedot client to be ready before issuing reads/extrinsics, so a mid-reconnect `system.remark` no longer throws "call `.connect()` first"

--- a/.changeset/next-dedot-smoldot-light-client.md
+++ b/.changeset/next-dedot-smoldot-light-client.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": minor
+---
+
+feat(next-dedot): connect through an in-browser smoldot light client by default (SmoldotProvider + @dedot/chain-specs in a Web Worker) instead of a remote RPC node, matching the next-papi stack

--- a/.changeset/next-dedot-smoldot-light-client.md
+++ b/.changeset/next-dedot-smoldot-light-client.md
@@ -2,4 +2,4 @@
 "create-dot-app": minor
 ---
 
-feat(next-dedot): connect through an in-browser smoldot light client by default (SmoldotProvider + @dedot/chain-specs in a Web Worker) instead of a remote RPC node, matching the next-papi stack
+feat(next-dedot): connect through an in-browser smoldot light client by default (SmoldotProvider + @dedot/chain-specs in a Web Worker) instead of a remote RPC node, matching the next-papi stack. This also fixes Paseo Asset Hub resolving to the wrong chain: the previous `wss://pas-rpc.stakeworld.io/assethub` endpoint actually served Polkadot Asset Hub, so the app showed DOT and an incorrect balance; the light client now syncs the correct chain from its chain spec (PAS).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A CLI tool to quickly bootstrap Polkadot-based decentralized applications with p
 npx create-dot-app@latest
 
 # Non-interactive mode
-npx create-dot-app@latest my-dapp --template react-papi
+npx create-dot-app@latest my-dapp --template next-papi
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ npx create-dot-app@latest my-dapp --template next-papi
 
 ## Features
 
-- 🚀 **Multiple Frameworks** - React, Vue, Next.js, Nuxt
+- ⚡ **Three Next.js stacks** - Solidity (Polkadot Hub EVM), Substrate via PAPI, Substrate via Dedot
 - 🔗 **Dual SDK Support** - [PAPI](https://papi.how/) and [Dedot](https://docs.dedot.dev/)
-- 🔨 **Smart Contracts** - Substrate Pallets, Solidity
+- 🪶 **Light client** - in-browser smoldot connectivity on the Substrate stacks
 - 📦 **Package Managers** - npm, yarn, pnpm, bun
 
 ## Documentation

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,7 +77,7 @@ npx create-dot-app@latest my-dapp --template next-dedot
 
 - `next` - Solidity (Next.js + Web3Auth + Wagmi, Polkadot Hub EVM)
 - `next-papi` - Substrate (Next.js + PAPI light client, Polkadot native)
-- `next-dedot` - Substrate (Next.js + Dedot SDK, Polkadot native)
+- `next-dedot` - Substrate (Next.js + Dedot light client, Polkadot native)
 
 ## Quick Start
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,11 +12,17 @@ Choose the Polkadot stack you want to build with:
 - **[Wagmi](https://wagmi.sh/)** for EVM wallet and contract interactions
 - **Solidity** smart contracts on Polkadot Hub (EVM)
 
-### 🟣 Substrate — `next-papi`
+### 🟣 Substrate (PAPI) — `next-papi`
 - **Next.js** (App Router) with React 19 and Tailwind CSS
 - **[PAPI](https://papi.how/)** (polkadot-api) for native Polkadot interaction
 - **[smoldot](https://github.com/smol-dot/smoldot)** light client transport
 - Connect Wallet plus a sample `system.remark` extrinsic, wired out of the box
+
+### 🟣 Substrate (Dedot) — `next-dedot`
+- **Next.js** (App Router) with React 19 and Tailwind CSS
+- **[Dedot](https://dedot.dev/)** SDK for native Polkadot interaction
+- Live block watcher, network switcher, Connect Wallet, and a sample `system.remark` extrinsic out of the box
+- Light client transport opt-in (swap `WsProvider` for Dedot's `SmoldotProvider`)
 
 ### 📦 Package Manager Support
 Compatible with npm, yarn, pnpm, and bun
@@ -38,7 +44,7 @@ Create a new Polkadot dApp project with interactive prompts:
 npx create-dot-app@latest
 ```
 
-Enter your project name when prompted, then pick a stack: **Solidity** (`next`) or **Substrate** (`next-papi`).
+Enter your project name when prompted, then pick a stack: **Solidity** (`next`), **Substrate (PAPI)** (`next-papi`), or **Substrate (Dedot)** (`next-dedot`).
 
 ### Non-Interactive Mode
 
@@ -51,8 +57,11 @@ npx create-dot-app@latest my-dapp
 # Solidity dapp (Polkadot Hub EVM)
 npx create-dot-app@latest my-dapp --template next
 
-# Substrate dapp (Polkadot native)
+# Substrate dapp, PAPI SDK (Polkadot native)
 npx create-dot-app@latest my-dapp --template next-papi
+
+# Substrate dapp, Dedot SDK (Polkadot native)
+npx create-dot-app@latest my-dapp --template next-dedot
 ```
 
 ### CLI Options
@@ -68,6 +77,7 @@ npx create-dot-app@latest my-dapp --template next-papi
 
 - `next` - Solidity (Next.js + Web3Auth + Wagmi, Polkadot Hub EVM)
 - `next-papi` - Substrate (Next.js + PAPI light client, Polkadot native)
+- `next-dedot` - Substrate (Next.js + Dedot SDK, Polkadot native)
 
 ## Quick Start
 
@@ -76,8 +86,9 @@ npx create-dot-app@latest my-dapp --template next-papi
 npx create-dot-app@latest
 
 # Non-interactive with a specific template
-npx create-dot-app@latest my-dapp --template next        # Solidity
-npx create-dot-app@latest my-dapp --template next-papi   # Substrate
+npx create-dot-app@latest my-dapp --template next         # Solidity
+npx create-dot-app@latest my-dapp --template next-papi    # Substrate (PAPI)
+npx create-dot-app@latest my-dapp --template next-dedot   # Substrate (Dedot)
 
 # Navigate to project directory
 cd my-dapp

--- a/cli/__tests__/cli.e2e.test.ts
+++ b/cli/__tests__/cli.e2e.test.ts
@@ -252,6 +252,41 @@ describe('cli E2E tests', () => {
     }
   })
 
+  it('creates Substrate project with --template=next-dedot', async () => {
+    const projectName = 'dedot-param-test'
+    const projectPath = path.join(testDir, projectName)
+
+    const { output } = await spawnCLI(testDir, {
+      args: [projectName, '--template=next-dedot'],
+      timeout: 60000,
+    })
+
+    // Verify output contains expected messages
+    expect(output).toContain('create-dot-app')
+    expect(output).toContain(`Using project name: ${projectName}`)
+    expect(output).toContain('Using template: next-dedot')
+    expect(output).toContain('Project created successfully!')
+
+    // Verify project directory was created
+    const projectExists = await fs.access(projectPath).then(() => true).catch(() => false)
+    expect(projectExists).toBe(true)
+
+    // Verify package.json has correct name and ships the Dedot SDK, which is what
+    // distinguishes this Substrate stack from the PAPI one (next-papi)
+    const packageJsonPath = path.join(projectPath, 'package.json')
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
+    expect(packageJson.name).toBe(projectName)
+    expect(packageJson.dependencies?.dedot).toBeDefined()
+
+    // Verify it's the Dedot template: ships next.config.ts but no PAPI descriptors (.papi)
+    const appPageExists = await fs.access(path.join(projectPath, 'app/page.tsx')).then(() => true).catch(() => false)
+    expect(appPageExists, 'File app/page.tsx should exist').toBe(true)
+    const nextConfigTsExists = await fs.access(path.join(projectPath, 'next.config.ts')).then(() => true).catch(() => false)
+    expect(nextConfigTsExists, 'File next.config.ts should exist').toBe(true)
+    const papiExists = await fs.access(path.join(projectPath, '.papi')).then(() => true).catch(() => false)
+    expect(papiExists, 'Dedot template should not ship a .papi directory').toBe(false)
+  })
+
   it('handles invalid --template parameter correctly', async () => {
     const projectName = 'invalid-template-test'
 
@@ -266,6 +301,7 @@ describe('cli E2E tests', () => {
     expect(output).toContain('Available templates:')
     expect(output).toContain('next')
     expect(output).toContain('next-papi')
+    expect(output).toContain('next-dedot')
   })
 
   it('creates project with --template parameter only (prompts for name)', async () => {

--- a/cli/__tests__/template-selector.test.ts
+++ b/cli/__tests__/template-selector.test.ts
@@ -22,10 +22,11 @@ describe('template selector', () => {
     isCancelMock.mockReturnValue(false)
   })
 
-  it('offers Solidity (next) and Substrate (next-papi) options', () => {
+  it('offers Solidity (next) and both Substrate stacks (next-papi, next-dedot)', () => {
     const byValue = Object.fromEntries(templateOptions.map(o => [o.value, o.label]))
     expect(byValue.next).toBe('Solidity')
-    expect(byValue['next-papi']).toBe('Substrate')
+    expect(byValue['next-papi']).toBe('Substrate (PAPI)')
+    expect(byValue['next-dedot']).toBe('Substrate (Dedot)')
   })
 
   it('returns the chosen template in interactive mode', async () => {
@@ -49,6 +50,7 @@ describe('template selector', () => {
 
   it('honors a valid provided template without prompting', async () => {
     expect(await pickTemplate('next-papi')).toBe('next-papi')
+    expect(await pickTemplate('next-dedot')).toBe('next-dedot')
     expect(await pickTemplate('next')).toBe('next')
     expect(selectMock).not.toHaveBeenCalled()
   })

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -83,8 +83,11 @@ ${color.bold('Examples:')}
   ${color.dim('# Solidity dapp (Polkadot Hub EVM)')}
   npx create-dot-app@latest my-dapp --template next
 
-  ${color.dim('# Substrate dapp (Polkadot native)')}
+  ${color.dim('# Substrate dapp, PAPI SDK (Polkadot native)')}
   npx create-dot-app@latest my-dapp --template next-papi
+
+  ${color.dim('# Substrate dapp, Dedot SDK (Polkadot native)')}
+  npx create-dot-app@latest my-dapp --template next-dedot
 
 ${color.bold('Learn more:')}
   ${color.underline('https://github.com/preschian/create-dot-app')}

--- a/cli/src/template-selector.ts
+++ b/cli/src/template-selector.ts
@@ -18,7 +18,7 @@ export const templateOptions: SelectOptions<string>['options'] = [
   {
     value: 'next-dedot',
     label: 'Substrate (Dedot)',
-    hint: 'Next.js + Dedot SDK, Polkadot native',
+    hint: 'Next.js + Dedot light client, Polkadot native',
   },
 ]
 

--- a/cli/src/template-selector.ts
+++ b/cli/src/template-selector.ts
@@ -12,8 +12,13 @@ export const templateOptions: SelectOptions<string>['options'] = [
   },
   {
     value: 'next-papi',
-    label: 'Substrate',
+    label: 'Substrate (PAPI)',
     hint: 'Next.js + PAPI light client, Polkadot native',
+  },
+  {
+    value: 'next-dedot',
+    label: 'Substrate (Dedot)',
+    hint: 'Next.js + Dedot SDK, Polkadot native',
   },
 ]
 

--- a/docs/src/components/landing/Stack.astro
+++ b/docs/src/components/landing/Stack.astro
@@ -1,7 +1,7 @@
 ---
 // The stack — five layers, UI down to the chain, with foundation notes.
 // The layers show the Solidity (next) track; a second note points to the
-// native Substrate (next-papi) alternative.
+// native Substrate alternatives (next-papi with PAPI, next-dedot with Dedot).
 import { STACK } from '../../data/landing';
 ---
 
@@ -38,6 +38,6 @@ import { STACK } from '../../data/landing';
     <svg viewBox="0 0 24 24" fill="none" width="1em" height="1em" aria-hidden="true">
       <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
     </svg>
-    <span class="lp-foundation-text">prefer native Substrate? the <strong>next-papi</strong> stack swaps wagmi and Hardhat for <strong>PAPI</strong> with a smoldot light client</span>
+    <span class="lp-foundation-text">prefer native Substrate? <strong>next-papi</strong> and <strong>next-dedot</strong> swap wagmi and Hardhat for <strong>PAPI</strong> or <strong>Dedot</strong></span>
   </div>
 </section>

--- a/templates/next-dedot/README.md
+++ b/templates/next-dedot/README.md
@@ -8,6 +8,7 @@ A modern **Next.js 16 + TypeScript + React 19** template for building Polkadot d
 - **React 19** for modern UI development
 - **TypeScript** for type safety
 - **Dedot SDK** integration for Polkadot blockchain interaction
+- **Light client** connectivity via smoldot — verifies the chain in-browser instead of trusting a single RPC node
 - **Type-safe chaintypes** via `@dedot/chaintypes` — no code generation step required
 - **TailwindCSS 4** styling with light/dark theme tokens and an accent picker
 - **Wallet Connection** support via Talisman Connect
@@ -21,10 +22,10 @@ This template uses **Dedot** - a lightweight, tree-shakable, type-safe SDK for i
 
 ### Connectivity
 
-Chains connect through a remote RPC node over WebSocket (`WsProvider`). Each chain pulls its types from `@dedot/chaintypes`, so storage queries, constants, and extrinsics are fully typed with no code generation step. Prefer an in-browser light client? dedot also ships a `SmoldotProvider` (from `dedot/smoldot`) you can drop in to verify the chain yourself instead of trusting a single endpoint.
+Chains connect through an in-browser **smoldot light client** (`SmoldotProvider`) rather than a remote RPC node, so the app verifies the chain itself instead of trusting a single endpoint. smoldot runs in a Web Worker, and each chain's spec (from `@dedot/chain-specs`) is loaded on demand via a dynamic import. The first connection to a chain warp-syncs and can take a few seconds; the asset hubs are parachains, so they also sync their relay chain (`dot` / `pas`) under the hood. Each chain pulls its types from `@dedot/chaintypes`, so storage queries, constants, and extrinsics are fully typed with no code generation step.
 
 ### Configuration Files:
-- **`app/utils/sdk.ts`** - Configures which chains to connect to. Each chain points to an RPC endpoint; edit this file to add or remove supported networks (or switch a chain over to the smoldot light client).
+- **`app/utils/sdk.ts`** - Configures which chains to connect to. Each chain runs through the smoldot light client; edit this file to add or remove supported networks (or switch a chain back to a remote RPC endpoint with `WsProvider`).
 - **`app/utils/sdk-interface.ts`** - Provides high-level functions for onchain SDK calls.
 
 ## 🌐 Supported Chains
@@ -74,7 +75,7 @@ Edit [`app/components/app.tsx`](app/components/app.tsx) — it composes the welc
 | `welcome/panels/LiveDemo.tsx` | Composes `BlockPanel` + `WritePanel` |
 | `welcome/panels/BlockPanel.tsx` | Live block watcher (`useCurrentBlock`) |
 | `welcome/panels/WritePanel.tsx` | Sample `system.remark` extrinsic + transaction stepper |
-| `welcome/panels/WalletConnect.tsx` | Connect Wallet button + connected menu (balance via the RPC connection) |
+| `welcome/panels/WalletConnect.tsx` | Connect Wallet button + connected menu (balance via the light client) |
 | `welcome/panels/ConnectModal.tsx` | Talisman wallet + account picker |
 | `welcome/panels/NetworkSwitch.tsx` | Network selector across the configured chains |
 | `welcome/panels/HeaderControls.tsx` | Accent picker + theme toggle |
@@ -85,7 +86,7 @@ Edit [`app/components/app.tsx`](app/components/app.tsx) — it composes the welc
 
 ### Step 1: Configure Your Chain
 
-Dedot reads chain types from `@dedot/chaintypes`, so there is no descriptor generation step. Edit `app/utils/sdk.ts` to add your chain, pointing it at an RPC endpoint and the matching chaintypes interface:
+Dedot reads chain types from `@dedot/chaintypes`, so there is no descriptor generation step. Edit `app/utils/sdk.ts` to add your chain, pointing it at a light-client chain spec (from `@dedot/chain-specs`) and the matching chaintypes interface:
 
 ```typescript
 import type { YourChainApi } from '@dedot/chaintypes'
@@ -93,13 +94,15 @@ import type { YourChainApi } from '@dedot/chaintypes'
 const CONFIG = {
   // ... existing chains
   your_chain: {
-    providers: ['wss://your-rpc-endpoint.io'],
     apiType: {} as YourChainApi,
+    chainSpec: () => import('@dedot/chain-specs/your_chain'),
+    // For a parachain, point `relay` at its relay chain's CONFIG key so it
+    // syncs through the right relay: relay: 'dot',
   },
 }
 ```
 
-If `@dedot/chaintypes` does not yet bundle types for your chain, you can generate them with the dedot CLI (`npx dedot chaintypes -w wss://your-rpc-endpoint.io`) or fall back to the generic `SubstrateApi` type.
+`@dedot/chain-specs` ships specs for the well-known Polkadot, Kusama, Paseo, and Westend chains (relay chains, asset hubs, and more). For any other chain, drop its chain-spec JSON into the project and import that instead, or switch it to a remote RPC endpoint with `new WsProvider('wss://your-rpc-endpoint.io')`. If `@dedot/chaintypes` does not yet bundle types for your chain, generate them with the dedot CLI (`npx dedot chaintypes -w wss://your-rpc-endpoint.io`) or fall back to the generic `SubstrateApi` type.
 
 ### Step 2: Add it to the UI
 
@@ -108,7 +111,7 @@ The network switch, block watcher, and balance read each chain's display metadat
 ```typescript
 export const NETWORKS: NetworkInfo[] = [
   // ... existing chains
-  { key: 'your_chain', name: 'Your Chain', chain: 'Your Chain', token: 'YRC', tag: 'MAINNET', color: '#E6007A', transport: 'your RPC' },
+  { key: 'your_chain', name: 'Your Chain', chain: 'Your Chain', token: 'YRC', tag: 'MAINNET', color: '#E6007A', transport: 'smoldot light client' },
 ]
 ```
 

--- a/templates/next-dedot/app/components/welcome/networks.ts
+++ b/templates/next-dedot/app/components/welcome/networks.ts
@@ -1,6 +1,6 @@
 // Display metadata for the chains the starter ships with, keyed to the dedot
 // `Prefix` values defined in app/utils/sdk.ts so the network switch, block
-// watcher, and balance all line up with what the RPC connection exposes.
+// watcher, and balance all line up with what the light client exposes.
 // Add an entry here when you add a chain to the `CONFIG` in app/utils/sdk.ts.
 import type { Prefix } from '../../utils/sdk'
 
@@ -22,7 +22,7 @@ export const NETWORKS: NetworkInfo[] = [
     token: 'DOT',
     tag: 'MAINNET',
     color: '#E6007A',
-    transport: 'stakeworld RPC',
+    transport: 'smoldot light client',
   },
   {
     key: 'dot_asset_hub',
@@ -31,7 +31,7 @@ export const NETWORKS: NetworkInfo[] = [
     token: 'DOT',
     tag: 'SYSTEM',
     color: '#7916F3',
-    transport: 'stakeworld RPC',
+    transport: 'smoldot light client',
   },
   {
     key: 'pas',
@@ -40,7 +40,7 @@ export const NETWORKS: NetworkInfo[] = [
     token: 'PAS',
     tag: 'TESTNET',
     color: '#56B4D3',
-    transport: 'stakeworld RPC',
+    transport: 'smoldot light client',
   },
   {
     key: 'pas_asset_hub',
@@ -49,7 +49,7 @@ export const NETWORKS: NetworkInfo[] = [
     token: 'PAS',
     tag: 'TESTNET',
     color: '#18A058',
-    transport: 'stakeworld RPC',
+    transport: 'smoldot light client',
   },
 ]
 

--- a/templates/next-dedot/app/utils/sdk-interface.ts
+++ b/templates/next-dedot/app/utils/sdk-interface.ts
@@ -32,7 +32,7 @@ export async function polkadotSigner(): Promise<InjectedSigner | undefined> {
   return wallet?.signer
 }
 
-// Watch the chain head over the RPC connection. `block.best()` streams each new
+// Watch the chain head over the light client connection. `block.best()` streams each new
 // best block and `block.finalized()` the latest finalized one; both are folded
 // into a single update so the UI can show the live height alongside the
 // finalized depth.

--- a/templates/next-dedot/app/utils/sdk.ts
+++ b/templates/next-dedot/app/utils/sdk.ts
@@ -1,30 +1,36 @@
 import type { PaseoApi, PaseoAssetHubApi, PolkadotApi, PolkadotAssetHubApi } from '@dedot/chaintypes'
 import { createAtom } from '@xstate/store'
-import { DedotClient, WsProvider } from 'dedot'
+import { DedotClient, SmoldotProvider } from 'dedot'
+import { startWithWorker } from 'dedot/smoldot/with-worker'
 
-// Each chain connects through a remote RPC node over WebSocket. `apiType` carries
-// the per-chain types from @dedot/chaintypes so storage queries, constants, and
-// extrinsics are fully typed without any code generation step.
+// Each chain connects through an in-browser smoldot light client instead of a
+// remote RPC node, so the app verifies the chain itself rather than trusting a
+// single endpoint. `apiType` carries the per-chain types from @dedot/chaintypes
+// so storage queries, constants, and extrinsics are fully typed without any code
+// generation step. `chainSpec` is loaded with a dynamic import so the (large)
+// spec JSON is only downloaded when that chain is actually used; parachains (the
+// asset hubs) declare the relay they sync against via `potentialRelayChains`.
 //
-// Prefer an in-browser light client instead? Swap `WsProvider` in `sdk()` below
-// for dedot's `SmoldotProvider` (from 'dedot/smoldot') so the app verifies the
-// chain itself rather than trusting a single endpoint.
+// Prefer a remote RPC instead? Swap the provider in `sdk()` below for
+// `new WsProvider('wss://...')` (also from 'dedot') and drop the smoldot wiring.
 const CONFIG = {
   dot: {
-    providers: ['wss://dot-rpc.stakeworld.io'],
     apiType: {} as PolkadotApi,
+    chainSpec: () => import('@dedot/chain-specs/polkadot'),
   },
   dot_asset_hub: {
-    providers: ['wss://dot-rpc.stakeworld.io/assethub'],
     apiType: {} as PolkadotAssetHubApi,
+    chainSpec: () => import('@dedot/chain-specs/polkadot_asset_hub'),
+    relay: 'dot',
   },
   pas: {
-    providers: ['wss://pas-rpc.stakeworld.io'],
     apiType: {} as PaseoApi,
+    chainSpec: () => import('@dedot/chain-specs/paseo'),
   },
   pas_asset_hub: {
-    providers: ['wss://pas-rpc.stakeworld.io/assethub'],
     apiType: {} as PaseoAssetHubApi,
+    chainSpec: () => import('@dedot/chain-specs/paseo_asset_hub'),
+    relay: 'pas',
   },
 } as const
 
@@ -34,11 +40,47 @@ export const chainKeys = Object.keys(CONFIG) as Prefix[]
 export type ApiTypeFor<T extends Prefix> = (typeof CONFIG)[T]['apiType']
 export type DedotApiFor<T extends Prefix> = Promise<DedotClient<ApiTypeFor<T>>>
 
-// Cache one client promise per prefix so a chain is connected once and reused
-// across the block watcher, balance reads, and the write path. Created lazily so
-// it never runs during SSR — `sdk()` is only called from client-side effects and
-// event handlers.
-const clients = createAtom<Partial<Record<Prefix, Promise<DedotClient<ApiTypeFor<Prefix>>>>>>({})
+type Smoldot = ReturnType<typeof startWithWorker>
+type SmoldotChain = Awaited<ReturnType<Smoldot['addChain']>>
+
+// One smoldot instance (running in a Web Worker, off the main thread) is shared
+// by every chain. Created lazily so it never runs during SSR — `sdk()` is only
+// ever called from client-side effects and event handlers.
+let smoldot: Smoldot | undefined
+
+function getSmoldot() {
+  if (!smoldot) {
+    smoldot = startWithWorker(
+      new Worker(new URL('dedot/smoldot/worker', import.meta.url), { type: 'module' }),
+    )
+  }
+
+  return smoldot
+}
+
+// Cache the smoldot chain per prefix so a relay chain (e.g. `dot`) is synced
+// once and reused both as its own chain and as the relay for its asset hub.
+const chainStore: Partial<Record<Prefix, Promise<SmoldotChain>>> = {}
+
+function getChain(chain: Prefix): Promise<SmoldotChain> {
+  if (!chainStore[chain]) {
+    chainStore[chain] = (async () => {
+      const entry = CONFIG[chain]
+      const { chainSpec } = await entry.chainSpec()
+
+      if ('relay' in entry) {
+        return getSmoldot().addChain({
+          chainSpec,
+          potentialRelayChains: [await getChain(entry.relay)],
+        })
+      }
+
+      return getSmoldot().addChain({ chainSpec })
+    })()
+  }
+
+  return chainStore[chain]!
+}
 
 // `api.registry` throws until the client has connected and fetched metadata, so
 // probing it tells us whether storage reads and extrinsics are safe to issue.
@@ -51,10 +93,11 @@ function hasMetadata(api: DedotClient<ApiTypeFor<Prefix>>): boolean {
   }
 }
 
-// A dropped socket — or dedot's staling watchdog forcing a reconnect — clears
-// the client's metadata registry until it reconnects and re-syncs. `api.query`
-// and `api.tx` read that registry synchronously, so touching them mid-reconnect
-// throws "call `.connect()` first". Hand back the client only once it's ready.
+// A dropped connection — or dedot's staling watchdog forcing a reconnect, which
+// a freshly warp-syncing light client can trigger — clears the client's metadata
+// registry until it re-syncs. `api.query` and `api.tx` read that registry
+// synchronously, so touching them mid-reconnect throws "call `.connect()` first".
+// Hand back the client only once it's ready.
 async function whenReady(api: DedotClient<ApiTypeFor<Prefix>>): Promise<DedotClient<ApiTypeFor<Prefix>>> {
   if (hasMetadata(api)) {
     return api
@@ -67,9 +110,15 @@ async function whenReady(api: DedotClient<ApiTypeFor<Prefix>>): Promise<DedotCli
   return api
 }
 
+// Cache one client promise per prefix so a chain is connected once and reused
+// across the block watcher, balance reads, and the write path. Created lazily so
+// it never runs during SSR — `sdk()` is only called from client-side effects and
+// event handlers.
+const clients = createAtom<Partial<Record<Prefix, Promise<DedotClient<ApiTypeFor<Prefix>>>>>>({})
+
 export default function sdk<T extends Prefix>(chain: T): { api: DedotApiFor<T> } {
   if (!clients.get()[chain]) {
-    clients.set({ ...clients.get(), [chain]: DedotClient.new(new WsProvider([...CONFIG[chain].providers])) })
+    clients.set({ ...clients.get(), [chain]: DedotClient.new(new SmoldotProvider(getChain(chain))) })
   }
 
   // Re-check readiness on every call rather than only at creation: the cached

--- a/templates/next-dedot/app/utils/sdk.ts
+++ b/templates/next-dedot/app/utils/sdk.ts
@@ -40,12 +40,41 @@ export type DedotApiFor<T extends Prefix> = Promise<DedotClient<ApiTypeFor<T>>>
 // event handlers.
 const clients = createAtom<Partial<Record<Prefix, Promise<DedotClient<ApiTypeFor<Prefix>>>>>>({})
 
+// `api.registry` throws until the client has connected and fetched metadata, so
+// probing it tells us whether storage reads and extrinsics are safe to issue.
+function hasMetadata(api: DedotClient<ApiTypeFor<Prefix>>): boolean {
+  try {
+    return Boolean(api.registry)
+  }
+  catch {
+    return false
+  }
+}
+
+// A dropped socket — or dedot's staling watchdog forcing a reconnect — clears
+// the client's metadata registry until it reconnects and re-syncs. `api.query`
+// and `api.tx` read that registry synchronously, so touching them mid-reconnect
+// throws "call `.connect()` first". Hand back the client only once it's ready.
+async function whenReady(api: DedotClient<ApiTypeFor<Prefix>>): Promise<DedotClient<ApiTypeFor<Prefix>>> {
+  if (hasMetadata(api)) {
+    return api
+  }
+
+  await new Promise<void>((resolve) => {
+    api.once('ready', () => resolve())
+  })
+
+  return api
+}
+
 export default function sdk<T extends Prefix>(chain: T): { api: DedotApiFor<T> } {
   if (!clients.get()[chain]) {
     clients.set({ ...clients.get(), [chain]: DedotClient.new(new WsProvider([...CONFIG[chain].providers])) })
   }
 
+  // Re-check readiness on every call rather than only at creation: the cached
+  // client is long-lived and may be mid-reconnect by the time a consumer awaits.
   return {
-    api: clients.get()[chain]! as DedotApiFor<T>,
+    api: clients.get()[chain]!.then(whenReady) as DedotApiFor<T>,
   }
 }

--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -12,13 +12,13 @@
     "@talismn/connect-wallets": "^1.2.8",
     "@xstate/store": "^4.1.0",
     "@xstate/store-react": "^2.0.0",
-    "dedot": "^1.0.2",
+    "dedot": "^1.3.0",
     "next": "16.2.7",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@dedot/chaintypes": "^0.214.0",
+    "@dedot/chaintypes": "^0.280.0",
     "@next/eslint-plugin-next": "^16.2.7",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^25.9.1",

--- a/templates/next-dedot/package.json
+++ b/templates/next-dedot/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint --fix ."
   },
   "dependencies": {
+    "@dedot/chain-specs": "^0.10.0",
     "@talismn/connect-wallets": "^1.2.8",
     "@xstate/store": "^4.1.0",
     "@xstate/store-react": "^2.0.0",


### PR DESCRIPTION
Adds the Substrate (Dedot) stack to the CLI and brings the `next-dedot` template up to par with `next-papi`.

- **CLI**: `next-dedot` is now a selectable stack alongside `next` (Solidity) and `next-papi`; the two Substrate options are disambiguated by SDK ("Substrate (PAPI)" / "Substrate (Dedot)"), with help text, README, docs landing note, and tests updated.
- **next-dedot fix**: a dropped socket / staling-watchdog reconnect clears dedot's metadata registry, so `api.query` / `api.tx` threw "call `.connect()` first" mid-reconnect; a `whenReady` guard now waits for the client to be ready before issuing reads/extrinsics.
- **next-dedot light client**: switched the default transport from a remote RPC (`WsProvider`) to an in-browser **smoldot light client** (`SmoldotProvider` + `@dedot/chain-specs` in a Web Worker, parachains wired to their relay), matching the next-papi stack.
- **Deps**: bumped `dedot` → ^1.3.0 and `@dedot/chaintypes` → ^0.280.0 (eslint intentionally stays on the latest 9.x).
- Also fixed a broken root-README example that referenced a non-selectable template.

Verified end to end on a fresh scaffold: `tsc`, `eslint`, and `next build` pass (smoldot worker + WASM bundle under Turbopack), and a runtime smoke test confirms the light client warp-syncs Paseo + its asset-hub parachain and serves queries/extrinsics. CLI unit + e2e suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)