### PR TITLE
fix(templates): load smoldot worker from a local file for Turbopack

### DIFF
--- a/.changeset/next-smoldot-worker-turbopack.md
+++ b/.changeset/next-smoldot-worker-turbopack.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": patch
+---
+
+fix(templates): load the smoldot Web Worker from a local file so it works under Next.js Turbopack. next-dedot and next-papi created the worker from a bare package specifier (`new Worker(new URL('dedot/smoldot/worker', ...))`), which Turbopack cannot resolve at runtime ("request.indexOf is not a function"), so the light client never connected. The worker now loads from a local `app/utils/smoldot-worker.ts` that dynamically imports the SDK worker (dynamic so it survives the production build's tree-shaking, since both SDKs ship `sideEffects: false`).

--- a/templates/next-dedot/app/utils/sdk.ts
+++ b/templates/next-dedot/app/utils/sdk.ts
@@ -51,7 +51,7 @@ let smoldot: Smoldot | undefined
 function getSmoldot() {
   if (!smoldot) {
     smoldot = startWithWorker(
-      new Worker(new URL('dedot/smoldot/worker', import.meta.url), { type: 'module' }),
+      new Worker(new URL('./smoldot-worker.ts', import.meta.url), { type: 'module' }),
     )
   }
 

--- a/templates/next-dedot/app/utils/smoldot-worker.ts
+++ b/templates/next-dedot/app/utils/smoldot-worker.ts
@@ -1,0 +1,10 @@
+// Worker entry for the smoldot light client. dedot ships the worker as
+// 'dedot/smoldot/worker', but Next.js/Turbopack only resolves a *relative* URL
+// literal in `new Worker(new URL('./…', import.meta.url))`; handing it a bare
+// package specifier makes Turbopack's worker loader throw "request.indexOf is
+// not a function" at runtime. So the Worker points at this local file and we
+// pull dedot's worker in here instead. The import is dynamic because dedot is
+// published with `sideEffects: false`, which lets the production build
+// tree-shake a plain `import 'dedot/smoldot/worker'` away (leaving an empty,
+// silent worker); a dynamic import is always retained.
+import('dedot/smoldot/worker')

--- a/templates/next-papi/app/utils/sdk.ts
+++ b/templates/next-papi/app/utils/sdk.ts
@@ -48,7 +48,7 @@ let smoldot: Smoldot | undefined
 function getSmoldot() {
   if (!smoldot) {
     smoldot = startFromWorker(
-      new Worker(new URL('polkadot-api/smoldot/worker', import.meta.url)),
+      new Worker(new URL('./smoldot-worker.ts', import.meta.url)),
     )
   }
 

--- a/templates/next-papi/app/utils/smoldot-worker.ts
+++ b/templates/next-papi/app/utils/smoldot-worker.ts
@@ -1,0 +1,11 @@
+// Worker entry for the smoldot light client. polkadot-api ships the worker as
+// 'polkadot-api/smoldot/worker', but Next.js/Turbopack only resolves a
+// *relative* URL literal in `new Worker(new URL('./…', import.meta.url))`;
+// handing it a bare package specifier makes Turbopack's worker loader throw
+// "request.indexOf is not a function" at runtime. So the Worker points at this
+// local file and we pull polkadot-api's worker in here instead. The import is
+// dynamic because polkadot-api is published with `sideEffects: false`, which
+// lets the production build tree-shake a plain
+// `import 'polkadot-api/smoldot/worker'` away (leaving an empty, silent
+// worker); a dynamic import is always retained.
+import('polkadot-api/smoldot/worker')


### PR DESCRIPTION
The next-dedot and next-papi templates created the smoldot Web Worker from a bare package specifier, which Next.js Turbopack cannot resolve: it throws `request.indexOf is not a function` at runtime, so the light client never connects. This points the Worker at a new local `app/utils/smoldot-worker.ts` in each template that dynamically imports the SDK worker. The import is dynamic so it survives the production build's tree-shaking, since both dedot and polkadot-api ship `sideEffects: false`. Verified with a headless-Chromium probe in both `next dev --turbopack` and a production build for each template: the error is gone, smoldot boots, and live block heights render. Includes a patch changeset for `create-dot-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
