### PR TITLE
fix(next-papi): add esbuild devDependency for Yarn v1 package-managers CI

### DIFF
--- a/.changeset/next-papi-yarn-esbuild.md
+++ b/.changeset/next-papi-yarn-esbuild.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": patch
+---
+
+fix(next-papi): add `esbuild` as an explicit devDependency so the `papi` postinstall works under Yarn Classic v1. Yarn v1 does not auto-install peer dependencies (npm/pnpm/bun do), so `rollup-plugin-esbuild` — pulled in by the polkadot-api CLI — could not resolve its `esbuild` peer, failing the package-managers CI with `ERR_MODULE_NOT_FOUND: Cannot find package 'esbuild'` before lint/build even ran.

--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.25.12",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.7",
     "tailwindcss": "^4.3.0",


### PR DESCRIPTION
## Problem

The **Package Managers** CI (`.github/workflows/package-managers.yml`) runs install → lint → build across `npm`, `yarn`, `pnpm`, and `bun`. The **yarn** job fails on the `next-papi` template:

```
$ papi
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'esbuild' imported from
  node_modules/rollup-plugin-esbuild/dist/index.mjs
```

## Root cause

The yarn job uses **Yarn Classic v1** (bundled with `actions/setup-node`, no separate Yarn setup step). **Yarn v1 does not auto-install peer dependencies** — npm, pnpm, and bun do, which is why only the yarn job failed.

`next-papi`'s `postinstall: papi` runs the polkadot-api CLI, which uses `rollup-plugin-esbuild`, which declares `esbuild` as a **peer dependency**. Under yarn v1 `esbuild` is never installed, so `papi` crashes before lint/build even run.

## Fix

Add `esbuild` as an explicit `devDependency` in `templates/next-papi/package.json` (one line). The other unmet peers it warns about (`@polkadot/api`, `@polkadot/extension-inject`, `rxjs`) are harmless — the Turbopack `next build` succeeds without them, so they were intentionally left out.

## Verification

Reproduced the exact CI flow with **Yarn Classic v1** (`yarn@1.22.22`) on a clean `git archive` checkout of the template:

| Step | Before | After |
|------|--------|-------|
| `yarn install` (postinstall `papi`) | ❌ `ERR_MODULE_NOT_FOUND: esbuild` | ✅ descriptors generated |
| `yarn run lint` | (not reached) | ✅ exit 0 |
| `yarn run build` | (not reached) | ✅ build succeeds |

## Notes for reviewers

- No-op for npm/pnpm/bun: `esbuild` was already present transitively, and it's already covered by `pnpm-workspace.yaml` `allowBuilds`/`onlyBuiltDependencies`.
- Templates ship **no lockfile** (`templates/**/bun.lock` is gitignored), so CI installs fresh from `package.json` — only `package.json` needed to change.
- Includes a changeset (`create-dot-app: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)