### PR TITLE
fix(templates): pin eslint to latest 9.x release

### DIFF
--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "esbuild": "^0.25.12",
-    "eslint": "^9.39.4",
+    "eslint": "9.39.4",
     "eslint-config-next": "^16.2.7",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3"

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@next/eslint-plugin-next": "^16.2.7",
-    "eslint": "^9.39.2",
+    "eslint": "9.39.4",
     "eslint-config-next": "^16.2.7",
     "typescript": "^5"
   }


### PR DESCRIPTION
Prevent caret ranges from resolving to ESLint 10 during installs.