### PR TITLE
ci: add Playwright workflow for MetaMask e2e tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,60 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tests/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/playwright.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'tests/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/playwright.yml'
+  workflow_dispatch:
+
+jobs:
+  playwright:
+    name: E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Download wallet extensions
+        run: bun run test:prepare
+
+      # MetaMask runs as a browser extension, which requires headed Chromium.
+      # Xvfb provides a virtual display so the headed browser can run on CI.
+      - name: Run Playwright tests
+        run: xvfb-run --auto-servernum -- bun run test
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report (on failure)
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   playwright:
     name: E2E
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "bun --cwd cli run build",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:prepare": "rm -rf .chroma && npx @avalix/chroma download-extensions"
+    "test:prepare": "bun node_modules/@avalix/chroma/scripts/download-extensions.ts"
   },
   "devDependencies": {
     "@avalix/chroma": "^1.0.1",


### PR DESCRIPTION
Adds a GitHub Actions workflow to run the template-next MetaMask e2e spec on CI. MetaMask runs as a browser extension requiring headed Chromium, so tests run under Xvfb. The job installs deps with Bun, downloads wallet extensions via `test:prepare`, and uploads the Playwright report as an artifact. It triggers on push/PR to `main` when test files change, plus manual dispatch. All actions use their latest major versions (checkout@v6, setup-node@v6, upload-artifact@v7, setup-bun@v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)