### PR TITLE
fix(deps): bump esbuild to ^0.28.1 in next-papi template

### DIFF
--- a/templates/next-papi/package.json
+++ b/templates/next-papi/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
-    "esbuild": "^0.25.12",
+    "esbuild": "^0.28.1",
     "eslint": "9.39.4",
     "eslint-config-next": "^16.2.7",
     "tailwindcss": "^4.3.0",


### PR DESCRIPTION
Resolves Dependabot alert #110 (high severity): `esbuild` versions `< 0.28.1` miss binary integrity verification in the Deno module, enabling RCE via `NPM_CONFIG_REGISTRY`. This bumps the `esbuild` devDependency in `templates/next-papi` from `^0.25.12` to the patched `^0.28.1`. It is the only template with an explicit `esbuild` pin, and no lockfile update is needed since templates are not part of the root workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)