### PR TITLE
feat(templates): add Nuxt (Vue) port of the Solidity template

### DIFF
--- a/.changeset/nuxt-solidity-template.md
+++ b/.changeset/nuxt-solidity-template.md
@@ -1,0 +1,5 @@
+---
+"create-dot-app": minor
+---
+
+feat(cli): add the `nuxt` template — a Nuxt (Vue 3) port of the Solidity / Polkadot Hub EVM starter. Selectable as "Solidity (Nuxt)" in the interactive prompt or via `--template nuxt`. It reproduces the Next.js welcome screen using `@wagmi/vue` + `@web3auth/modal/vue` + `@tanstack/vue-query` and reuses the Hardhat/PolkaVM contracts workspace, running as a client SPA.

--- a/.github/workflows/package-manager.yml
+++ b/.github/workflows/package-manager.yml
@@ -22,6 +22,8 @@ jobs:
           filters: |
             next:
               - 'templates/next/**'
+            nuxt:
+              - 'templates/nuxt/**'
 
       - name: Set matrix based on changes
         id: set-matrix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ create-dot-app/
 │   └── package.json       # CLI package config
 ├── templates/             # Project templates
 │   ├── next/             # Solidity (Next.js + Wagmi, Polkadot Hub EVM)
-│   └── next-papi/        # Substrate (Next.js + PAPI light client)
+│   ├── next-papi/        # Substrate (Next.js + PAPI light client)
+│   └── nuxt/             # Solidity (Nuxt + Wagmi, Polkadot Hub EVM)
 ├── docs/                  # Documentation site
 └── package.json          # Root package config
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,12 @@ Choose the Polkadot stack you want to build with:
 - **[smoldot](https://github.com/smol-dot/smoldot)** light client transport
 - Connect Wallet plus a sample `system.remark` extrinsic, wired out of the box
 
+### 💚 Solidity (Nuxt) - `nuxt`
+- **Nuxt** (Vue 3) with Tailwind CSS, rendered as a client-side SPA
+- **[Web3Auth](https://web3auth.io/)** social/embedded wallet login
+- **[Wagmi for Vue](https://wagmi.sh/vue)** for EVM wallet and contract interactions
+- **Solidity** smart contracts on Polkadot Hub (EVM)
+
 ### 📦 Package Manager Support
 Compatible with npm, yarn, pnpm, and bun
 
@@ -38,7 +44,7 @@ Create a new Polkadot dApp project with interactive prompts:
 npx create-dot-app@latest
 ```
 
-Enter your project name when prompted, then pick a stack: **Solidity** (`next`) or **Substrate (PAPI)** (`next-papi`).
+Enter your project name when prompted, then pick a stack: **Solidity** (`next`), **Substrate (PAPI)** (`next-papi`), or **Solidity (Nuxt)** (`nuxt`).
 
 ### Non-Interactive Mode
 
@@ -53,6 +59,9 @@ npx create-dot-app@latest my-dapp --template next
 
 # Substrate dapp, PAPI SDK (Polkadot native)
 npx create-dot-app@latest my-dapp --template next-papi
+
+# Solidity dapp on Nuxt (Polkadot Hub EVM)
+npx create-dot-app@latest my-dapp --template nuxt
 ```
 
 ### CLI Options
@@ -68,6 +77,7 @@ npx create-dot-app@latest my-dapp --template next-papi
 
 - `next` - Solidity (Next.js + Web3Auth + Wagmi, Polkadot Hub EVM)
 - `next-papi` - Substrate (Next.js + PAPI light client, Polkadot native)
+- `nuxt` - Solidity (Nuxt + Web3Auth + Wagmi, Polkadot Hub EVM)
 
 ## Quick Start
 
@@ -78,6 +88,7 @@ npx create-dot-app@latest
 # Non-interactive with a specific template
 npx create-dot-app@latest my-dapp --template next         # Solidity
 npx create-dot-app@latest my-dapp --template next-papi    # Substrate (PAPI)
+npx create-dot-app@latest my-dapp --template nuxt         # Solidity (Nuxt)
 
 # Navigate to project directory
 cd my-dapp

--- a/cli/__tests__/template-selector.test.ts
+++ b/cli/__tests__/template-selector.test.ts
@@ -22,10 +22,16 @@ describe('template selector', () => {
     isCancelMock.mockReturnValue(false)
   })
 
-  it('offers Solidity (next) and the Substrate stack (next-papi)', () => {
+  it('offers Solidity (next), the Substrate stack (next-papi), and Nuxt (nuxt)', () => {
     const byValue = Object.fromEntries(templateOptions.map(o => [o.value, o.label]))
     expect(byValue.next).toBe('Solidity')
     expect(byValue['next-papi']).toBe('Substrate (PAPI)')
+    expect(byValue.nuxt).toBe('Solidity (Nuxt)')
+  })
+
+  it('honors the nuxt template without prompting', async () => {
+    expect(await pickTemplate('nuxt')).toBe('nuxt')
+    expect(selectMock).not.toHaveBeenCalled()
   })
 
   it('returns the chosen template in interactive mode', async () => {

--- a/cli/src/template-selector.ts
+++ b/cli/src/template-selector.ts
@@ -15,6 +15,11 @@ export const templateOptions: SelectOptions<string>['options'] = [
     label: 'Substrate (PAPI)',
     hint: 'Next.js + PAPI light client, Polkadot native',
   },
+  {
+    value: 'nuxt',
+    label: 'Solidity (Nuxt)',
+    hint: 'Nuxt + Web3Auth + Wagmi, Polkadot Hub EVM',
+  },
 ]
 
 export async function pickTemplate(providedTemplate?: string, interactive = true): Promise<string> {

--- a/templates/nuxt/.env.example
+++ b/templates/nuxt/.env.example
@@ -1,0 +1,3 @@
+# Web3Auth Client ID — a demo Sapphire Devnet project ships as the default in
+# nuxt.config.ts. Get your own at https://dashboard.web3auth.io and uncomment to override.
+# NUXT_PUBLIC_WEB3AUTH_CLIENT_ID=YOUR_CLIENT_ID

--- a/templates/nuxt/.gitignore
+++ b/templates/nuxt/.gitignore
@@ -1,0 +1,40 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# nuxt
+.nuxt
+.output
+.data
+.nitro
+.cache
+dist
+
+# testing
+/coverage
+
+# misc
+.DS_Store
+*.pem
+logs
+*.log
+
+# local env files
+.env
+.env.*
+!.env.example
+
+# editor / vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+
+# hardhat (contracts/)
+contracts/node_modules
+contracts/cache
+contracts/artifacts
+contracts/typechain-types
+contracts/coverage
+contracts/ignition/deployments

--- a/templates/nuxt/.yarnrc.yml
+++ b/templates/nuxt/.yarnrc.yml
@@ -1,0 +1,5 @@
+# Yarn Berry (v2+) defaults to Plug'n'Play, which Nuxt/Vite can't load (their
+# build steps assume a real node_modules layout). Use the classic node_modules
+# linker so the template builds the same way it does on npm/bun/pnpm.
+# Yarn Classic (v1) ignores this file and already defaults to node_modules.
+nodeLinker: node-modules

--- a/templates/nuxt/README.md
+++ b/templates/nuxt/README.md
@@ -1,0 +1,149 @@
+# create-dot-app — Nuxt (Polkadot Hub)
+
+A [Nuxt](https://nuxt.com) starter for building dapps on **Polkadot Hub**. The first-run
+home page is a live welcome screen — a real-time block watcher, a network switcher,
+Connect Wallet, and a sample transaction — all wired up so you can confirm the stack
+works the moment it boots.
+
+Wallet connection is powered by **Web3Auth (MetaMask Embedded Wallets)** and on-chain
+reads/writes by **[@wagmi/vue](https://wagmi.sh/vue)**, pointed at the three Polkadot Hub
+EVM networks: Passet Hub Testnet (PAS), Polkadot Hub (DOT), and Kusama Hub (KSM). The
+provider tree is rendered client-side (`<ClientOnly>`) since Web3Auth + wagmi are
+browser-only, while the document head is served by Nuxt.
+
+## Prerequisites
+
+- Node.js 20+
+- npm
+- A Client ID from the [Web3Auth Dashboard](https://dashboard.web3auth.io)
+
+## Setup
+
+### 1. Install dependencies
+
+Installs the Nuxt app and the Hardhat workspace under `contracts/` (npm workspaces).
+
+```bash
+npm install
+```
+
+### 2. Configure environment variables (optional)
+
+A demo Sapphire Devnet Client ID ships as the default in `nuxt.config.ts`, so the app
+runs out of the box. To use your own, create a `.env`:
+
+```bash
+cp .env.example .env
+```
+
+and set:
+
+```
+NUXT_PUBLIC_WEB3AUTH_CLIENT_ID=YOUR_CLIENT_ID
+```
+
+After deploying on testnet, set Flipper and Remark addresses in [`app/lib/contracts/addresses.ts`](app/lib/contracts/addresses.ts).
+
+> Use **Sapphire Devnet** (the default) for local development — Sapphire Mainnet does
+> not allow localhost.
+
+### 3. Run the application
+
+```bash
+npm run dev
+```
+
+Visit `http://localhost:3000`.
+
+## Project structure
+
+```text
+app/
+  app.vue               Web3Auth + wagmi provider tree (client-only)
+  pages/index.vue       the route rendered at /
+  components/
+    welcome/            first-run welcome demo (replace with your own UI)
+      AppWelcome.vue    ← start here: top bar, hero, features, side rail
+      icons/            presentational icon primitives + live dot
+    web3/               provider shell + chain restriction
+  composables/          useDismissible, useWagmiRemount
+  lib/
+    web3/               wallet + chain wiring: Web3Auth config, chain configs
+    welcome/            theme tokens, network metadata, copy, helpers
+    contracts/          contract ABIs + deployed addresses, typed for wagmi
+  assets/css/main.css   Tailwind CSS 4 entry + welcome animations
+  plugins/vue-query.ts  installs TanStack Query (wagmi's data layer)
+config/                 build-time module stubs referenced by nuxt.config.ts
+contracts/              Hardhat workspace (npm workspace) — Solidity, tests, deploy
+public/                 static assets
+```
+
+Imports use Nuxt's `~/*` alias (mapped to `app/`), e.g.
+`import { polkadotChains } from "~/lib/web3/chains"`.
+
+## Where to start
+
+Edit [`app/components/welcome/AppWelcome.vue`](app/components/welcome/AppWelcome.vue) — it
+composes the welcome screen and is the natural place to start building your own UI. Styling
+uses **Tailwind CSS 4** utility classes with theme tokens exposed as CSS variables
+(`--paper`, `--ink`, `--acc`, …) on the welcome root. The pieces it pulls in live in
+[`app/components/welcome/`](app/components/welcome):
+
+| File | Responsibility |
+| --- | --- |
+| `AppWelcome.vue` | Top bar, hero, features, side rail; owns theme + selected-network state |
+| `welcome/LiveDemo.vue` | Composes `BlockPanel` + `WritePanel` |
+| `welcome/BlockPanel.vue` | Live block watcher (`useBlockNumber`) |
+| `welcome/WritePanel.vue` | Sample contract writes + transaction stepper |
+| `welcome/WalletConnect.vue` | Connect Wallet button + connected menu (Web3Auth + `useBalance`) |
+| `welcome/NetworkSwitch.vue` | Network selector (`useSwitchChain`) |
+| `welcome/HeaderUtilities.vue` | Accent picker + theme toggle |
+| `welcome/PopoverPanel.vue`, `welcome/icons/` | Shared UI primitives (dropdown panel, icon set) |
+
+Providers and chain config live under [`app/components/web3/`](app/components/web3) and
+[`app/lib/web3/`](app/lib/web3):
+
+- [`app/app.vue`](app/app.vue) — Web3Auth provider + client-only boundary
+- [`app/components/web3/Web3Shell.vue`](app/components/web3/Web3Shell.vue) — wagmi provider + remount wiring
+- [`app/components/web3/RestrictPolkadotChains.vue`](app/components/web3/RestrictPolkadotChains.vue) — keeps wagmi to the three Hub chains
+- [`app/lib/web3/chains.ts`](app/lib/web3/chains.ts) — the three Polkadot Hub chain configs
+
+## Smart contracts
+
+The [`contracts/`](contracts/) directory is a [Hardhat](https://docs.polkadot.com/smart-contracts/dev-environments/hardhat/) workspace (`hardhat`) in the same npm monorepo as the app. See [`contracts/README.md`](contracts/README.md).
+
+```bash
+npm run compile:contracts
+npm run test:contracts
+npm run deploy:contracts   # requires PRIVATE_KEY — see contracts/README.md
+```
+
+`compile:contracts` exports the ABIs to `app/lib/contracts/`.
+
+## Scripts
+
+```bash
+npm run dev                # start the dev server
+npm run build              # production build
+npm run preview            # serve the production build
+npm run generate           # static-site (prerender) build
+npm run typecheck          # vue-tsc type check
+npm run lint               # eslint (@nuxt/eslint flat config)
+npm run compile:contracts  # compile Solidity and export ABIs to app/lib/contracts/
+npm run test:contracts     # Hardhat tests
+npm run deploy:contracts   # deploy Flipper + Remark to Polkadot Hub TestNet
+```
+
+This template uses the non-deprecated `@wagmi/vue` APIs — `useConnection`, and `mutate`
+from `useSwitchChain` / `useWriteContract` — per the [wagmi migration guide](https://wagmi.sh/react/guides/migrate-from-v2-to-v3).
+
+## Resources
+
+- [Polkadot Smart Contracts docs](https://docs.polkadot.com/develop/smart-contracts/)
+- [MetaMask Embedded Wallets / Web3Auth docs](https://docs.metamask.io/embedded-wallets/)
+- [wagmi for Vue documentation](https://wagmi.sh/vue)
+- [Nuxt documentation](https://nuxt.com/docs)
+
+## License
+
+MIT

--- a/templates/nuxt/app/app.vue
+++ b/templates/nuxt/app/app.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { Web3AuthProvider } from '@web3auth/modal/vue'
+import Web3Shell from '~/components/web3/Web3Shell.vue'
+import { createWeb3AuthConfig } from '~/lib/web3/config'
+
+// Web3Auth + wagmi are browser-only; the app is a client-rendered SPA (see
+// `ssr: false` in nuxt.config.ts). The static document head lives there too.
+const runtimeConfig = useRuntimeConfig()
+const web3AuthContextConfig = createWeb3AuthConfig(runtimeConfig.public.web3authClientId)
+</script>
+
+<template>
+  <Web3AuthProvider :config="web3AuthContextConfig">
+    <Web3Shell>
+      <NuxtPage />
+    </Web3Shell>
+  </Web3AuthProvider>
+</template>

--- a/templates/nuxt/app/assets/css/main.css
+++ b/templates/nuxt/app/assets/css/main.css
@@ -1,0 +1,61 @@
+@import "tailwindcss";
+
+@custom-variant welcome-md (@media (max-width: 920px));
+@custom-variant welcome-sm (@media (max-width: 560px));
+
+@theme {
+  --font-sans: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
+
+  --welcome-header-inset: 1.25rem;
+
+  --animate-dapp-ping: dappPing 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+  --animate-block-bump: blockBump 0.45s cubic-bezier(0.2, 0.8, 0.2, 1);
+  --animate-popover-rise: popoverRise 0.14s ease-out;
+  --animate-ns-spin: nsSpin 0.7s linear infinite;
+}
+
+@keyframes dappPing {
+  75%,
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+@keyframes blockBump {
+  0% {
+    transform: translateY(-0.2em);
+    color: inherit;
+  }
+  30% {
+    color: var(--acc);
+  }
+  100% {
+    transform: translateY(0);
+    color: inherit;
+  }
+}
+
+@keyframes popoverRise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes nsSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}

--- a/templates/nuxt/app/components/web3/Web3Shell.vue
+++ b/templates/nuxt/app/components/web3/Web3Shell.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+// Wallet + chain wiring: keeps wagmi restricted to the three Polkadot Hub
+// networks and remounts `<WagmiProvider>` whenever that set changes, so wagmi's
+// derived config stays in sync with Web3Auth.
+import { WagmiProvider } from '@web3auth/modal/vue/wagmi'
+import { provideWagmiRemount } from '~/composables/useWagmiRemount'
+import { useRestrictPolkadotChains } from '~/composables/useRestrictPolkadotChains'
+
+const { wagmiKey, remountWagmi } = provideWagmiRemount()
+useRestrictPolkadotChains(remountWagmi)
+</script>
+
+<template>
+  <WagmiProvider :key="wagmiKey">
+    <slot />
+  </WagmiProvider>
+</template>

--- a/templates/nuxt/app/components/welcome/AccentPicker.vue
+++ b/templates/nuxt/app/components/welcome/AccentPicker.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { ACCENTS } from '~/lib/welcome/theme'
+import { useDismissible } from '~/composables/useDismissible'
+import PopoverPanel from './PopoverPanel.vue'
+
+defineProps<{ accent: string }>()
+const emit = defineEmits<{ pick: [color: string] }>()
+
+const open = ref(false)
+const wrapRef = ref<HTMLElement | null>(null)
+useDismissible(open, () => (open.value = false), wrapRef)
+
+const iconBtn
+  = 'inline-flex size-[39px] shrink-0 cursor-pointer items-center justify-center border border-(--line) bg-transparent transition-[border-color,color] duration-150 hover:border-(--acc) hover:text-(--acc)'
+
+function choose(color: string) {
+  emit('pick', color)
+  open.value = false
+}
+</script>
+
+<template>
+  <span ref="wrapRef" class="relative inline-flex">
+    <button
+      type="button"
+      :class="iconBtn"
+      title="Accent color"
+      aria-label="Choose accent color"
+      @click="open = !open"
+    >
+      <span class="inline-block size-4 rounded-full" :style="{ background: accent }" />
+    </button>
+    <PopoverPanel v-if="open" panel-class="right-0 z-30 flex gap-[9px] px-[13px] py-[11px] welcome-sm:right-0">
+      <button
+        v-for="c in ACCENTS"
+        :key="c"
+        type="button"
+        :title="c"
+        :aria-label="`Use accent ${c}`"
+        class="size-6 shrink-0 cursor-pointer rounded-full border-0 p-0 transition-transform duration-150 hover:scale-110"
+        :style="{
+          background: c,
+          boxShadow: c === accent ? '0 0 0 2px var(--card), 0 0 0 3.5px var(--ink)' : 'none',
+        }"
+        @click="choose(c)"
+      />
+    </PopoverPanel>
+  </span>
+</template>

--- a/templates/nuxt/app/components/welcome/AppWelcome.vue
+++ b/templates/nuxt/app/components/welcome/AppWelcome.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+// Editorial first-run welcome screen for create-dot-app. Reproduces the design
+// 1:1 (layout, type, accent picker, light/dark), with the live block watcher,
+// network switch, Connect Wallet, and sample transaction wired to the template's
+// real wagmi + Web3Auth composables.
+import { computed, ref } from 'vue'
+import { useSwitchChain } from '@wagmi/vue'
+import { DEFAULT_ACCENT, themeVars, tokens } from '~/lib/welcome/theme'
+import { NETWORKS, networkByChainId } from '~/lib/welcome/networks'
+import { CLI, FEATURES, HEADLINE, HERO_BLURB, RESOURCES } from '~/lib/welcome/data'
+import HeaderUtilities from './HeaderUtilities.vue'
+import NetworkSwitch from './NetworkSwitch.vue'
+import WalletConnect from './WalletConnect.vue'
+import LiveDemo from './LiveDemo.vue'
+import IcArrow from './icons/IcArrow.vue'
+
+const dark = ref(false)
+const accent = ref(DEFAULT_ACCENT)
+const chainId = ref(NETWORKS[0]!.chainId)
+
+const { mutate: switchChain } = useSwitchChain()
+
+const net = computed(() => networkByChainId(chainId.value))
+const themeStyle = computed(() => themeVars(tokens(dark.value), accent.value))
+
+function onSwitch(id: number) {
+  chainId.value = id
+  try {
+    switchChain({ chainId: id })
+  }
+  catch {
+    /* wallet may not be connected yet — the selection still drives the read paths */
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen w-full bg-(--paper) font-sans text-(--ink)" :style="themeStyle">
+    <div class="mx-auto min-h-screen max-w-[1280px] border-x border-(--line)">
+      <header class="sticky top-0 z-10 overflow-visible border-b border-(--line) bg-(color-mix(in_srgb,var(--paper)_82%,transparent)) px-(--welcome-header-inset) py-3.5 backdrop-blur-md sm:px-10 sm:py-5">
+        <div class="flex flex-col gap-3 overflow-visible sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex items-baseline gap-3">
+              <span class="text-lg font-bold tracking-tight">
+                create<span class="text-(--acc)">·</span>app
+              </span>
+              <span class="font-mono text-[11.5px] text-(--faint)">v1.0</span>
+            </div>
+            <div class="flex shrink-0 items-center gap-2 sm:hidden">
+              <HeaderUtilities
+                :accent="accent"
+                :dark="dark"
+                @accent-pick="accent = $event"
+                @toggle-dark="dark = !dark"
+              />
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-2 overflow-visible sm:flex-row sm:items-center sm:gap-3">
+            <div class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-visible">
+              <NetworkSwitch :net="net" @switch="onSwitch($event)" />
+              <WalletConnect :chain-id="net.chainId" />
+            </div>
+            <div class="hidden shrink-0 items-center gap-2 sm:flex">
+              <HeaderUtilities
+                :accent="accent"
+                :dark="dark"
+                @accent-pick="accent = $event"
+                @toggle-dark="dark = !dark"
+              />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section class="grid items-end gap-12 border-b border-(--line) px-10 pt-16 pb-11 welcome-md:grid-cols-1 welcome-sm:gap-6 welcome-sm:px-5 welcome-sm:py-9 lg:grid-cols-[1fr_320px]">
+        <h1 class="m-0 max-w-[9ch] text-[84px] leading-[0.95] font-bold tracking-[-0.04em] welcome-md:text-[13vw]">
+          {{ HEADLINE }}
+        </h1>
+        <p class="m-0 pb-2.5 text-[16.5px] leading-snug text-(--dim)">
+          <span class="font-medium text-(--ink)">{{ CLI }}</span> {{ HERO_BLURB }}
+        </p>
+      </section>
+
+      <LiveDemo :net="net" @switch="onSwitch($event)" />
+
+      <div class="grid welcome-md:grid-cols-1 lg:grid-cols-[1fr_340px]">
+        <div class="grid grid-cols-2 border-r border-(--line) welcome-md:border-r-0 welcome-sm:grid-cols-1">
+          <div
+            v-for="(f, i) in FEATURES"
+            :key="f.title"
+            class="p-6 px-7 transition-[background] duration-150 hover:bg-(color-mix(in_srgb,var(--acc)_5%,transparent))"
+            :class="[
+              i % 2 === 0 ? 'border-r border-(--line) welcome-sm:border-r-0' : '',
+              i < FEATURES.length - 2 ? 'border-b border-(--line)' : '',
+            ]"
+          >
+            <div class="flex items-baseline gap-2.5">
+              <span class="font-mono text-xs font-semibold text-(--acc)">
+                {{ String(i + 1).padStart(2, '0') }}
+              </span>
+              <span class="text-lg font-semibold tracking-tight">{{ f.title }}</span>
+            </div>
+            <p class="mt-2 mb-0 text-[13.5px] leading-snug text-(--dim)">{{ f.desc }}</p>
+          </div>
+        </div>
+
+        <aside class="flex flex-col welcome-md:border-t welcome-md:border-(--line)">
+          <div class="border-b border-(--line) bg-(color-mix(in_srgb,var(--acc)_10%,transparent)) p-6 px-7">
+            <div class="font-mono text-[11px] font-semibold tracking-widest text-(--acc)">START HERE</div>
+            <div class="mt-2 text-[17px] leading-snug font-semibold">
+              Edit <span class="font-mono text-sm font-medium text-(--acc)">app/components/welcome/AppWelcome.vue</span> and save. It
+              reloads instantly.
+            </div>
+          </div>
+          <div class="flex flex-1 flex-col gap-0.5 p-5 px-7">
+            <div class="mb-2 font-mono text-[11px] font-semibold tracking-widest text-(--faint)">RESOURCES</div>
+            <a
+              v-for="(r, i) in RESOURCES"
+              :key="r.label"
+              :href="r.href"
+              target="_blank"
+              rel="noreferrer"
+              class="group flex items-center justify-between py-3 text-(--ink) no-underline transition-colors duration-150 hover:text-(--acc)"
+              :class="i < RESOURCES.length - 1 ? 'border-b border-(--line)' : ''"
+            >
+              <span>
+                <span class="block text-[15px] font-medium">{{ r.label }}</span>
+                <span class="mt-px block font-mono text-[11px] text-(--faint)">{{ r.meta }}</span>
+              </span>
+              <IcArrow class="text-[17px] text-(--faint) transition-transform duration-150 group-hover:translate-x-[3px]" />
+            </a>
+          </div>
+        </aside>
+      </div>
+
+      <footer class="flex flex-wrap items-center justify-between gap-3 border-t border-(--line) px-10 py-[18px] welcome-sm:px-5">
+        <span class="font-mono text-[11.5px] text-(--faint)">
+          generated by <span class="text-(--dim)">npm create dot-app@latest</span>
+        </span>
+        <span class="font-mono text-[11.5px] text-(--faint)">MIT · Polkadot-native</span>
+      </footer>
+    </div>
+  </div>
+</template>

--- a/templates/nuxt/app/components/welcome/BlockPanel.vue
+++ b/templates/nuxt/app/components/welcome/BlockPanel.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useBlockNumber, useChains, useConfig } from '@wagmi/vue'
+import { getBlock } from '@wagmi/vue/actions'
+import type { NetworkInfo } from '~/lib/welcome/networks'
+import { EYEBROW, LIVE_CELL } from '~/lib/welcome/shared'
+import LiveDot from './icons/LiveDot.vue'
+
+const props = defineProps<{ net: NetworkInfo }>()
+
+const chains = useChains()
+const config = useConfig()
+const chainReady = computed(() => chains.value.some((c) => c.id === props.net.chainId))
+
+const { data: blockNumber } = useBlockNumber({
+  chainId: computed(() => (chainReady.value ? props.net.chainId : undefined)),
+  watch: chainReady,
+  query: { enabled: chainReady },
+})
+
+// @wagmi/vue has no `useBlock`, so fetch the head block's hash whenever the
+// watched block number advances.
+const hash = ref<string | null>(null)
+watch(
+  [blockNumber, chainReady],
+  async ([number, ready]) => {
+    if (!ready || number === undefined) {
+      hash.value = null
+      return
+    }
+    try {
+      const head = await getBlock(config, { chainId: props.net.chainId, blockNumber: number })
+      hash.value = head.hash
+    }
+    catch {
+      /* transient RPC error — keep the previous hash */
+    }
+  },
+  { immediate: true },
+)
+
+const block = computed(() => blockNumber.value ?? null)
+const reconnecting = computed(() => !chainReady.value || block.value === null)
+const finalized = computed(() => (block.value !== null ? block.value - 3n : null))
+const blockDigits = computed(() =>
+  block.value === null ? [] : Number(block.value).toLocaleString('en-US').split(''),
+)
+
+const stats = computed<[string, string][]>(() => [
+  ['Finalized', finalized.value !== null ? `#${Number(finalized.value).toLocaleString('en-US')}` : '—'],
+  ['Chain', props.net.chain],
+  ['Token', props.net.token],
+])
+</script>
+
+<template>
+  <div class="border-r border-(--line) welcome-md:border-r-0 welcome-md:border-b" :class="LIVE_CELL">
+    <div class="flex items-center justify-between">
+      <span :class="EYEBROW">NETWORK</span>
+      <span
+        class="inline-flex items-center gap-2 font-mono text-[11.5px]"
+        :class="reconnecting ? 'text-(--faint)' : 'text-(--dim)'"
+      >
+        <LiveDot :color="reconnecting ? 'var(--faint)' : net.color" />
+        {{ reconnecting ? 'connecting…' : 'connected' }}
+      </span>
+    </div>
+
+    <div class="mt-[18px] flex items-baseline gap-2.5">
+      <span class="font-mono text-[15px] font-semibold text-(--acc)">#</span>
+      <span class="inline-block font-mono text-[clamp(36px,5.2vw,52px)] leading-none font-semibold tracking-tight text-(--ink) tabular-nums welcome-sm:text-[clamp(34px,11vw,52px)]">
+        <template v-if="block !== null">
+          <span
+            v-for="(ch, i) in blockDigits"
+            :key="`${i}-${ch}`"
+            class="inline-block animate-block-bump"
+          >{{ ch }}</span>
+        </template>
+        <template v-else>—</template>
+      </span>
+    </div>
+    <div class="mt-2 font-mono text-xs text-(--faint)">
+      {{ hash ? `${hash.slice(0, 10)}…` : '0x…' }} · ~3s block time
+    </div>
+
+    <div class="mt-5 flex flex-wrap gap-x-7 gap-y-3.5">
+      <div v-for="[k, v] in stats" :key="k">
+        <div class="font-mono text-[10.5px] tracking-widest text-(--faint)">{{ k.toUpperCase() }}</div>
+        <div class="mt-1 font-mono text-sm text-(--ink)">{{ v }}</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/templates/nuxt/app/components/welcome/HeaderUtilities.vue
+++ b/templates/nuxt/app/components/welcome/HeaderUtilities.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import AccentPicker from './AccentPicker.vue'
+import ThemeToggle from './ThemeToggle.vue'
+
+defineProps<{ accent: string, dark: boolean }>()
+const emit = defineEmits<{ accentPick: [color: string], toggleDark: [] }>()
+</script>
+
+<template>
+  <AccentPicker :accent="accent" @pick="emit('accentPick', $event)" />
+  <ThemeToggle :dark="dark" @toggle="emit('toggleDark')" />
+</template>

--- a/templates/nuxt/app/components/welcome/LiveDemo.vue
+++ b/templates/nuxt/app/components/welcome/LiveDemo.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { NetworkInfo } from '~/lib/welcome/networks'
+import BlockPanel from './BlockPanel.vue'
+import WritePanel from './WritePanel.vue'
+
+defineProps<{ net: NetworkInfo }>()
+const emit = defineEmits<{ switch: [chainId: number] }>()
+</script>
+
+<template>
+  <div class="grid grid-cols-2 border-b border-(--line) welcome-md:grid-cols-1">
+    <BlockPanel :net="net" />
+    <WritePanel :net="net" @switch="emit('switch', $event)" />
+  </div>
+</template>

--- a/templates/nuxt/app/components/welcome/NetworkSwitch.vue
+++ b/templates/nuxt/app/components/welcome/NetworkSwitch.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+// Top-bar network selector. Click to open a dropdown of the available chains;
+// selecting one commits immediately via the parent-owned chain id.
+import { ref } from 'vue'
+import { NETWORKS, type NetworkInfo, rpcHost } from '~/lib/welcome/networks'
+import { useDismissible } from '~/composables/useDismissible'
+import PopoverPanel from './PopoverPanel.vue'
+import LiveDot from './icons/LiveDot.vue'
+import IcCheck from './icons/IcCheck.vue'
+
+const props = defineProps<{ net: NetworkInfo }>()
+const emit = defineEmits<{ switch: [chainId: number] }>()
+
+const open = ref(false)
+const wrapRef = ref<HTMLElement | null>(null)
+useDismissible(open, () => (open.value = false), wrapRef)
+
+function choose(n: NetworkInfo) {
+  if (n.chainId === props.net.chainId) {
+    open.value = false
+    return
+  }
+  emit('switch', n.chainId)
+  open.value = false
+}
+</script>
+
+<template>
+  <span ref="wrapRef" class="relative inline-flex min-w-0 overflow-visible welcome-sm:w-full">
+    <button
+      type="button"
+      aria-label="Switch network"
+      class="inline-flex min-w-0 cursor-pointer items-center gap-2 border border-(--line) bg-transparent px-3 py-2 font-mono text-[12.5px] font-medium text-(--ink) transition-[border-color,background] duration-150 hover:border-(--acc) welcome-sm:w-full sm:gap-2.25 sm:py-2.25"
+      @click="open = !open"
+    >
+      <LiveDot :color="net.color" size="md" />
+      <span class="min-w-0 truncate sm:whitespace-nowrap">
+        <span class="sm:hidden">{{ net.chain }}</span>
+        <span class="hidden sm:inline">{{ net.name }}</span>
+      </span>
+      <svg
+        viewBox="0 0 24 24"
+        width="13"
+        height="13"
+        fill="none"
+        class="shrink-0 transition-transform duration-150"
+        :class="open ? 'rotate-180' : ''"
+      >
+        <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+
+    <PopoverPanel v-if="open" panel-class="sm:left-auto sm:right-0 sm:w-[308px] sm:max-w-[308px]">
+      <div class="border-b border-(--line) px-[18px] pt-[13px] pb-[11px]">
+        <div class="font-mono text-[10.5px] font-semibold tracking-[0.12em] text-(--faint)">
+          SWITCH NETWORK
+        </div>
+      </div>
+      <button
+        v-for="(n, i) in NETWORKS"
+        :key="n.id"
+        type="button"
+        class="flex w-full cursor-pointer items-center gap-3 px-[18px] py-[13px] text-left transition-[background] duration-150 hover:bg-(color-mix(in_srgb,var(--acc)_8%,transparent))"
+        :class="[
+          n.chainId === net.chainId ? 'bg-(color-mix(in_srgb,var(--acc)_6%,transparent))' : 'bg-transparent',
+          i < NETWORKS.length - 1 ? 'border-b border-(--line)' : '',
+        ]"
+        @click="choose(n)"
+      >
+        <span class="size-2.5 shrink-0 rounded-full" :style="{ background: n.color }" />
+        <span class="min-w-0 flex-1">
+          <span class="flex items-center gap-2">
+            <span class="text-[14.5px] font-semibold text-(--ink)">{{ n.name }}</span>
+            <span
+              class="rounded-[3px] border px-[5px] py-px font-mono text-[9px] font-semibold tracking-[0.08em]"
+              :style="{ color: n.color, borderColor: `color-mix(in srgb, ${n.color} 45%, transparent)` }"
+            >
+              {{ n.tag }}
+            </span>
+          </span>
+          <span class="mt-[3px] block truncate font-mono text-[11px] text-(--faint)">
+            {{ rpcHost(n.rpc) }}
+          </span>
+        </span>
+        <span class="inline-flex w-[18px] shrink-0 items-center justify-center">
+          <IcCheck v-if="n.chainId === net.chainId" class="text-base text-(--acc)" />
+        </span>
+      </button>
+    </PopoverPanel>
+  </span>
+</template>

--- a/templates/nuxt/app/components/welcome/PopoverPanel.vue
+++ b/templates/nuxt/app/components/welcome/PopoverPanel.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const shell
+  = 'absolute top-[calc(100%+8px)] z-40 animate-popover-rise border border-(--line) bg-(--card) shadow-(0_18px_50px_rgba(0,0,0,.18))'
+
+const mobileDefault
+  = 'welcome-sm:left-0 welcome-sm:right-auto welcome-sm:w-[calc(100vw-2*var(--welcome-header-inset))] welcome-sm:max-w-none'
+
+withDefaults(
+  defineProps<{
+    /** e.g. w-72 for wallet menu, sm:w-[308px] for network list */
+    panelClass?: string
+    /** Mobile panel width; defaults to viewport minus header padding */
+    mobileClass?: string
+  }>(),
+  { panelClass: '', mobileClass: mobileDefault },
+)
+</script>
+
+<template>
+  <div :class="[shell, mobileClass, panelClass]">
+    <slot />
+  </div>
+</template>

--- a/templates/nuxt/app/components/welcome/ThemeToggle.vue
+++ b/templates/nuxt/app/components/welcome/ThemeToggle.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps<{ dark: boolean }>()
+const emit = defineEmits<{ toggle: [] }>()
+
+const iconBtn
+  = 'inline-flex size-[39px] shrink-0 cursor-pointer items-center justify-center border border-(--line) bg-transparent transition-[border-color,color] duration-150 hover:border-(--acc) hover:text-(--acc)'
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="[iconBtn, 'text-(--ink)']"
+    title="Toggle light / dark"
+    aria-label="Toggle light or dark mode"
+    @click="emit('toggle')"
+  >
+    <span class="relative inline-block size-4 overflow-hidden rounded-full border-[1.5px] border-current">
+      <span
+        class="absolute top-0 bottom-0 w-1/2 bg-current transition-[left,right] duration-200"
+        :class="dark ? 'right-0 left-auto' : 'left-0 right-auto'"
+      />
+    </span>
+  </button>
+</template>

--- a/templates/nuxt/app/components/welcome/WalletConnect.vue
+++ b/templates/nuxt/app/components/welcome/WalletConnect.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+// Connect Wallet control. The button + connected-state dropdown are styled per
+// the design; the actual connect/disconnect is driven by the real Web3Auth modal
+// and the connected account's balance comes from wagmi.
+import { computed, ref } from 'vue'
+import { useWeb3AuthConnect, useWeb3AuthDisconnect, useWeb3AuthUser } from '@web3auth/modal/vue'
+import { useBalance, useChains, useConnection } from '@wagmi/vue'
+import { formatUnits } from 'viem'
+import { formatAddress } from '~/lib/welcome/format'
+import { useDismissible } from '~/composables/useDismissible'
+import PopoverPanel from './PopoverPanel.vue'
+import IcWallet from './icons/IcWallet.vue'
+
+const props = defineProps<{ chainId: number }>()
+
+const { connect, isConnected, loading: connecting } = useWeb3AuthConnect()
+const { disconnect } = useWeb3AuthDisconnect()
+const { userInfo } = useWeb3AuthUser()
+const { address, connector } = useConnection()
+const chains = useChains()
+const chainReady = computed(() => chains.value.some((c) => c.id === props.chainId))
+
+const { data: balance } = useBalance({
+  address,
+  chainId: computed(() => (chainReady.value ? props.chainId : undefined)),
+  query: { enabled: computed(() => Boolean(address.value) && chainReady.value) },
+})
+
+const menu = ref(false)
+const wrapRef = ref<HTMLElement | null>(null)
+useDismissible(menu, () => (menu.value = false), wrapRef)
+
+const connected = computed(() => isConnected.value && Boolean(address.value))
+const label = computed(() => userInfo.value?.name || userInfo.value?.email || 'Account')
+const shortAddress = computed(() => (address.value ? formatAddress(address.value) : ''))
+const balanceText = computed(() => {
+  const value = balance.value?.value
+  if (value === undefined) return '—'
+  return Number(formatUnits(value, balance.value!.decimals)).toLocaleString('en-US', {
+    maximumFractionDigits: 4,
+  })
+})
+
+function disconnectAll() {
+  menu.value = false
+  disconnect()
+}
+</script>
+
+<template>
+  <span ref="wrapRef" class="relative inline-flex">
+    <button
+      v-if="connected"
+      type="button"
+      class="inline-flex max-w-full min-w-0 cursor-pointer items-center gap-2 border-[1.5px] border-(--acc) bg-transparent px-3 py-2 font-mono text-xs font-medium text-(--ink) transition-[transform,background,color] duration-150 hover:-translate-y-px sm:max-w-none sm:px-4 sm:py-2.5 sm:text-[13px]"
+      @click="menu = !menu"
+    >
+      <span class="inline-block size-2 shrink-0 rounded-full bg-(--acc) sm:size-2.25" />
+      <span class="truncate">
+        <span class="hidden sm:inline">{{ label }} · </span>
+        {{ shortAddress }}
+      </span>
+    </button>
+    <button
+      v-else
+      type="button"
+      :disabled="connecting"
+      class="inline-flex shrink-0 cursor-pointer items-center gap-2 border-[1.5px] border-(--ink) bg-transparent px-3 py-2 font-mono text-xs font-medium whitespace-nowrap text-(--ink) transition-[transform,background,color] duration-150 hover:-translate-y-px disabled:cursor-default disabled:opacity-70 sm:px-4 sm:py-2.5 sm:text-[13px]"
+      @click="connect()"
+    >
+      <IcWallet class="text-[15px]" />
+      <span class="sm:hidden">{{ connecting ? '…' : 'Connect' }}</span>
+      <span class="hidden sm:inline">{{ connecting ? 'Connecting…' : 'Connect Wallet' }}</span>
+    </button>
+
+    <PopoverPanel v-if="connected && menu" panel-class="right-0 z-30 w-72 welcome-sm:right-0">
+      <div class="border-b border-(--line) px-[18px] py-4">
+        <div class="flex items-center gap-2.5">
+          <span class="inline-flex size-[30px] shrink-0 items-center justify-center rounded-full bg-(--acc) font-mono text-[13px] font-semibold text-white">
+            {{ label[0]?.toUpperCase() }}
+          </span>
+          <div class="min-w-0">
+            <div class="text-[15px] font-semibold text-(--ink)">{{ label }}</div>
+            <div class="font-mono text-[11px] text-(--faint)">via {{ connector?.name ?? 'Web3Auth' }}</div>
+          </div>
+        </div>
+        <div class="mt-3.25 flex items-baseline justify-between">
+          <span class="font-mono text-[10.5px] tracking-widest text-(--faint)">BALANCE</span>
+          <span class="font-mono text-[15px] tabular-nums text-(--ink)">
+            {{ balanceText }} <span class="text-xs text-(--dim)">{{ balance?.symbol ?? '' }}</span>
+          </span>
+        </div>
+        <div class="mt-1 break-all font-mono text-[11px] text-(--dim)">{{ shortAddress }}</div>
+      </div>
+      <button
+        type="button"
+        class="block w-full cursor-pointer border-0 bg-transparent px-[18px] py-3 text-left text-[13.5px] text-(--acc) transition-[background] duration-150 hover:bg-(color-mix(in_srgb,var(--acc)_8%,transparent))"
+        @click="disconnectAll"
+      >
+        Disconnect
+      </button>
+    </PopoverPanel>
+  </span>
+</template>

--- a/templates/nuxt/app/components/welcome/WritePanel.vue
+++ b/templates/nuxt/app/components/welcome/WritePanel.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import {
+  useChains,
+  useConfig,
+  useConnection,
+  useReadContract,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from '@wagmi/vue'
+import { waitForTransactionReceipt } from '@wagmi/vue/actions'
+import { useWeb3AuthConnect } from '@web3auth/modal/vue'
+import type { Abi, BaseError } from 'viem'
+import { TESTNET, explorerTxUrl, type NetworkInfo } from '~/lib/welcome/networks'
+import { formatAddress } from '~/lib/welcome/format'
+import { flipperAbi, flipperAddressForChain, remarkAbi, remarkAddressForChain } from '~/lib/contracts'
+import {
+  EYEBROW,
+  LIVE_CELL,
+  REMARK_MESSAGE,
+  WRITE_ACTIONS,
+  WRITE_STEPS,
+  type WriteActionKey,
+} from '~/lib/welcome/shared'
+import IcArrow from './icons/IcArrow.vue'
+import IcCheck from './icons/IcCheck.vue'
+
+const props = defineProps<{ net: NetworkInfo }>()
+const emit = defineEmits<{ switch: [chainId: number] }>()
+
+const config = useConfig()
+const chains = useChains()
+const chainReady = computed(() => chains.value.some((c) => c.id === props.net.chainId))
+const { isConnected, connect } = useWeb3AuthConnect()
+const { address } = useConnection()
+
+const flipperAddress = computed(() => flipperAddressForChain(props.net.chainId))
+const remarkAddress = computed(() => remarkAddressForChain(props.net.chainId))
+
+const { data: flipValue, refetch: refetchFlip } = useReadContract({
+  address: flipperAddress,
+  abi: flipperAbi as Abi,
+  functionName: 'get',
+  chainId: computed(() => props.net.chainId),
+  query: { enabled: computed(() => Boolean(flipperAddress.value) && chainReady.value) },
+})
+
+const { mutate, data: txHash, error: txError, isPending, reset } = useWriteContract()
+const { isLoading: isConfirming, isSuccess: isConfirmed, data: receipt } = useWaitForTransactionReceipt({
+  hash: txHash,
+})
+
+const actionKey = ref<WriteActionKey>('remark')
+const action = computed(() => WRITE_ACTIONS[actionKey.value])
+const actions = Object.values(WRITE_ACTIONS)
+
+const contractAddress = computed(() => (actionKey.value === 'flip' ? flipperAddress.value : remarkAddress.value))
+const actionBlocked = computed(() => !contractAddress.value)
+const actionLabel = computed(() => (actionKey.value === 'flip' ? 'flipper.flip' : 'system.remark'))
+const isTestnet = computed(() => props.net.chainId === TESTNET.chainId)
+const missingContractName = computed(() => (actionKey.value === 'flip' ? 'flipper' : 'remark'))
+
+watch(() => props.net.chainId, () => reset())
+
+const stage = computed(() => (isConfirmed.value ? 3 : txHash.value ? 2 : isPending.value ? 1 : -1))
+const pending = computed(
+  () => isPending.value || (Boolean(txHash.value) && isConfirming.value && !isConfirmed.value),
+)
+
+const flipValueText = computed(() => (flipValue.value === undefined ? '…' : String(flipValue.value)))
+const signerLabel = computed(() =>
+  isConnected.value && address.value ? formatAddress(address.value, 8, 4) : 'not connected',
+)
+const errorText = computed(() => {
+  const error = txError.value as unknown as BaseError | null
+  return error ? error.shortMessage || error.message : ''
+})
+const txHashShort = computed(() => (txHash.value ? formatAddress(txHash.value, 8, 4) : ''))
+const txExplorerUrl = computed(() => (txHash.value ? explorerTxUrl(props.net, txHash.value) : undefined))
+const receiptBlock = computed(() =>
+  receipt.value ? Number(receipt.value.blockNumber).toLocaleString('en-US') : '',
+)
+
+function pickAction(key: WriteActionKey) {
+  if (pending.value) return
+  actionKey.value = key
+  reset()
+}
+
+function submit() {
+  if (pending.value || actionBlocked.value) return
+  if (!isConnected.value || !address.value) {
+    connect()
+    return
+  }
+  reset()
+
+  if (actionKey.value === 'flip' && flipperAddress.value) {
+    mutate(
+      {
+        address: flipperAddress.value,
+        abi: flipperAbi as Abi,
+        functionName: 'flip',
+        chainId: props.net.chainId,
+      },
+      {
+        onSuccess: async (hash) => {
+          await waitForTransactionReceipt(config, { hash, chainId: props.net.chainId })
+          void refetchFlip()
+        },
+      },
+    )
+    return
+  }
+
+  if (actionKey.value === 'remark' && remarkAddress.value) {
+    mutate({
+      address: remarkAddress.value,
+      abi: remarkAbi as Abi,
+      functionName: 'remark',
+      args: [REMARK_MESSAGE],
+      chainId: props.net.chainId,
+    })
+  }
+}
+</script>
+
+<template>
+  <div :class="LIVE_CELL">
+    <div class="flex items-center justify-between">
+      <span :class="EYEBROW">TRY THE WRITE PATH</span>
+      <span class="font-mono text-[11.5px] text-(--faint)">signer: {{ signerLabel }}</span>
+    </div>
+
+    <div class="mt-3.5 inline-flex gap-0.5 self-start border border-(--line) p-0.5">
+      <button
+        v-for="a in actions"
+        :key="a.key"
+        type="button"
+        class="cursor-pointer border-0 px-3 py-1.5 font-mono text-[11.5px] font-semibold transition-[background,color] duration-150"
+        :class="[
+          pending && a.key !== actionKey ? 'cursor-default opacity-50' : '',
+          a.key === actionKey ? 'bg-(--acc) text-(--paper)' : 'bg-transparent text-(--dim)',
+        ]"
+        @click="pickAction(a.key)"
+      >
+        {{ a.tab }}{{ a.key === 'flip' ? '()' : '' }}
+      </button>
+    </div>
+
+    <div class="min-h-[130px]">
+      <div v-if="actionBlocked" class="mt-3 border border-dashed border-(--line) px-4 py-3.5">
+        <div class="flex items-center gap-2.25">
+          <span class="size-1.75 shrink-0 rounded-full bg-(--faint)" />
+          <div class="text-[17px] font-semibold tracking-tight text-(--ink)">
+            No {{ missingContractName }} contract on {{ net.chain }}
+          </div>
+        </div>
+        <p class="mt-1.5 mb-0 text-[13px] leading-normal text-(--dim)">
+          Run <span class="font-mono text-xs text-(--acc)">npm run deploy:contracts</span> then set
+          <span class="font-mono text-xs text-(--acc)">{{ missingContractName }}</span> in
+          <span class="font-mono text-xs text-(--acc)">app/lib/contracts/addresses.ts</span> (testnet).
+        </p>
+        <button
+          v-if="!isTestnet"
+          type="button"
+          class="group mt-2.5 inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 font-mono text-[12.5px] font-semibold whitespace-nowrap text-(--acc)"
+          @click="emit('switch', TESTNET.chainId)"
+        >
+          Switch to {{ TESTNET.chain }}
+          <IcArrow class="text-sm transition-transform duration-150 group-hover:translate-x-[3px]" />
+        </button>
+      </div>
+
+      <template v-else>
+        <div class="mt-3.5 flex items-start justify-between gap-5 welcome-sm:flex-col welcome-sm:items-stretch welcome-sm:gap-3.5">
+          <div class="min-w-0">
+            <div class="text-xl font-semibold tracking-tight text-(--ink)">{{ action.title }}</div>
+            <div class="mt-1.5 font-mono text-[12.5px] text-(--dim)">
+              <template v-if="actionKey === 'flip'">
+                flipper.flip() · value: <span class="text-(--acc)">{{ flipValueText }}</span>
+              </template>
+              <template v-else>
+                system.remark(<span class="text-(--acc)">&quot;{{ REMARK_MESSAGE }}&quot;</span>)
+              </template>
+            </div>
+          </div>
+          <button
+            type="button"
+            :disabled="pending"
+            class="inline-flex min-w-[172px] shrink-0 items-center justify-center gap-2 border-[1.5px] border-(--acc) px-[18px] py-[11px] font-mono text-[13px] font-semibold whitespace-nowrap transition-[transform,background,color] duration-150 welcome-sm:w-full"
+            :class="
+              pending
+                ? 'cursor-default bg-transparent text-(--acc) opacity-70'
+                : 'cursor-pointer bg-(--acc) text-(--paper) hover:-translate-y-px'
+            "
+            @click="submit"
+          >
+            {{ pending ? 'Submitting…' : stage === 3 ? 'Run again' : !isConnected ? 'Connect to send' : action.cta }}
+            <IcArrow v-if="!pending" class="text-[15px]" />
+          </button>
+        </div>
+
+        <div class="mt-[18px] flex items-center">
+          <template v-for="(labelText, i) in WRITE_STEPS" :key="labelText">
+            <div class="flex items-center gap-1.75">
+              <span
+                class="inline-block size-[11px] shrink-0 rounded-full border-[1.5px] transition-all duration-200"
+                :class="[
+                  stage >= i ? 'border-(--acc) bg-(--acc)' : 'border-(--line) bg-transparent',
+                  stage >= i && i === stage && pending
+                    ? 'shadow-(0_0_0_4px_color-mix(in_srgb,var(--acc)_22%,transparent))'
+                    : '',
+                ]"
+              />
+              <span
+                class="font-mono text-[11.5px] transition-colors duration-200"
+                :class="stage >= i ? 'text-(--ink)' : 'text-(--faint)'"
+              >{{ labelText }}</span>
+            </div>
+            <div
+              v-if="i < WRITE_STEPS.length - 1"
+              class="mx-2.25 h-[1.5px] flex-1 transition-[background] duration-200"
+              :class="stage > i ? 'bg-(--acc)' : 'bg-(--line)'"
+            />
+          </template>
+        </div>
+
+        <div class="mt-3.5 flex min-h-[22px] flex-col gap-1.5">
+          <div v-if="errorText" class="font-mono text-xs text-(--acc)">{{ errorText }}</div>
+          <div v-else-if="isConfirmed && txHash" class="flex items-center gap-2.5 font-mono text-xs">
+            <span class="inline-flex items-center gap-1.25 font-semibold text-(--acc)">
+              <IcCheck class="text-[13px]" /> Finalized
+            </span>
+            <span class="text-(--faint)">{{ actionLabel }}</span>
+            <a
+              :href="txExplorerUrl"
+              target="_blank"
+              rel="noreferrer"
+              title="View transaction on the block explorer"
+              class="text-(--dim) no-underline transition-colors duration-150 hover:text-(--acc)"
+            >
+              {{ txHashShort }}
+            </a>
+            <span v-if="receipt" class="ml-auto text-(--faint)">in #{{ receiptBlock }}</span>
+          </div>
+          <div v-else class="font-mono text-xs text-(--faint)">No extrinsics submitted yet.</div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/templates/nuxt/app/components/welcome/icons/IcArrow.vue
+++ b/templates/nuxt/app/components/welcome/icons/IcArrow.vue
@@ -1,0 +1,5 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" width="1em" height="1em">
+    <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>
+</template>

--- a/templates/nuxt/app/components/welcome/icons/IcCheck.vue
+++ b/templates/nuxt/app/components/welcome/icons/IcCheck.vue
@@ -1,0 +1,5 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" width="1em" height="1em">
+    <path d="M4 12.5 9.5 18 20 6.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>
+</template>

--- a/templates/nuxt/app/components/welcome/icons/IcWallet.vue
+++ b/templates/nuxt/app/components/welcome/icons/IcWallet.vue
@@ -1,0 +1,7 @@
+<template>
+  <svg viewBox="0 0 24 24" fill="none" width="1em" height="1em">
+    <rect x="3" y="6" width="18" height="13" rx="3" stroke="currentColor" stroke-width="1.7" />
+    <path d="M3 10h18" stroke="currentColor" stroke-width="1.7" />
+    <circle cx="16.5" cy="14.5" r="1.3" fill="currentColor" />
+  </svg>
+</template>

--- a/templates/nuxt/app/components/welcome/icons/LiveDot.vue
+++ b/templates/nuxt/app/components/welcome/icons/LiveDot.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+// A small animated "live" status dot used by the network indicator.
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{ color: string, size?: 'sm' | 'md' }>(), {
+  size: 'sm',
+})
+
+const sizeClass = computed(() => (props.size === 'md' ? 'size-2.25' : 'size-2'))
+</script>
+
+<template>
+  <span class="relative inline-flex shrink-0" :class="sizeClass">
+    <span class="absolute inset-0 animate-dapp-ping rounded-full opacity-45" :style="{ background: color }" />
+    <span class="absolute inset-0 rounded-full" :style="{ background: color }" />
+  </span>
+</template>

--- a/templates/nuxt/app/composables/useDismissible.ts
+++ b/templates/nuxt/app/composables/useDismissible.ts
@@ -1,0 +1,37 @@
+import { onScopeDispose, watch, type Ref } from 'vue'
+
+/** Close on Escape and pointer-down outside `containerRef` while `open` is true. */
+export function useDismissible(
+  open: Ref<boolean>,
+  onClose: () => void,
+  containerRef: Ref<HTMLElement | null>,
+) {
+  let cleanup: (() => void) | null = null
+
+  const teardown = () => {
+    cleanup?.()
+    cleanup = null
+  }
+
+  watch(open, (isOpen) => {
+    teardown()
+    if (!isOpen || typeof window === 'undefined') return
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    const onDown = (e: MouseEvent) => {
+      const el = containerRef.value
+      if (el && !el.contains(e.target as Node)) onClose()
+    }
+
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('mousedown', onDown)
+    cleanup = () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('mousedown', onDown)
+    }
+  })
+
+  onScopeDispose(teardown)
+}

--- a/templates/nuxt/app/composables/useRestrictPolkadotChains.ts
+++ b/templates/nuxt/app/composables/useRestrictPolkadotChains.ts
@@ -1,0 +1,34 @@
+import { watch } from 'vue'
+import { useWeb3Auth } from '@web3auth/modal/vue'
+import { polkadotChains } from '~/lib/web3/chains'
+
+/**
+ * Web3Auth merges dashboard chains with code config. Force coreOptions to only
+ * the three Polkadot Hub networks so wagmi does not list Ethereum or others.
+ * Calls `remountWagmi` when it has to drop extra chains, so the wagmi config is
+ * rebuilt from the restricted set. Must run inside `<Web3AuthProvider>`.
+ */
+export function useRestrictPolkadotChains(remountWagmi: () => void) {
+  const { web3Auth, isInitialized } = useWeb3Auth()
+
+  watch(
+    isInitialized,
+    (initialized) => {
+      const instance = web3Auth.value
+      if (!initialized || !instance) return
+
+      const allowed = new Set(polkadotChains.map((chain) => chain.chainId))
+      const merged = instance.coreOptions.chains ?? []
+      const hasExtraChains
+        = merged.length !== polkadotChains.length
+          || merged.some((chain) => !allowed.has(chain.chainId))
+
+      if (hasExtraChains) {
+        // Web3Auth exposes mutable coreOptions; reassignment is required to drop dashboard chains.
+        instance.coreOptions.chains = [...polkadotChains]
+        remountWagmi()
+      }
+    },
+    { immediate: true },
+  )
+}

--- a/templates/nuxt/app/composables/useWagmiRemount.ts
+++ b/templates/nuxt/app/composables/useWagmiRemount.ts
@@ -1,0 +1,28 @@
+import { inject, provide, ref, type InjectionKey, type Ref } from 'vue'
+
+interface WagmiRemount {
+  /** Bump this to force-remount `<WagmiProvider>` and rebuild its wagmi config. */
+  wagmiKey: Ref<number>
+  remountWagmi: () => void
+}
+
+const WAGMI_REMOUNT_KEY: InjectionKey<WagmiRemount> = Symbol('wagmi-remount')
+
+/** Set up the remount context. Call once in the provider shell. */
+export function provideWagmiRemount(): WagmiRemount {
+  const wagmiKey = ref(0)
+  const remountWagmi = () => {
+    wagmiKey.value += 1
+  }
+  const value = { wagmiKey, remountWagmi }
+  provide(WAGMI_REMOUNT_KEY, value)
+  return value
+}
+
+export function useWagmiRemount(): WagmiRemount {
+  const value = inject(WAGMI_REMOUNT_KEY)
+  if (!value) {
+    throw new Error('useWagmiRemount must be used within the Web3 provider shell')
+  }
+  return value
+}

--- a/templates/nuxt/app/lib/contracts/addresses.ts
+++ b/templates/nuxt/app/lib/contracts/addresses.ts
@@ -1,0 +1,28 @@
+import { kusamaHub, polkadotHub, polkadotHubTestnet } from '@/lib/web3/chains'
+
+const id = (chain: { chainId: string }) => Number.parseInt(chain.chainId, 16)
+
+/**
+ * Deployed demo contracts per Polkadot Hub EVM chain.
+ * Set testnet addresses after `npm run deploy:contracts`.
+ * Mainnet and Kusama Hub stay unset until you deploy there.
+ */
+const FLIPPER_ADDRESS_BY_CHAIN_ID: Record<number, `0x${string}` | undefined> = {
+  [id(polkadotHubTestnet)]: '0xC71323A95Eb9a1DCc545b7E3cfb0906cA014eb67',
+  [id(polkadotHub)]: undefined,
+  [id(kusamaHub)]: undefined,
+}
+
+const REMARK_ADDRESS_BY_CHAIN_ID: Record<number, `0x${string}` | undefined> = {
+  [id(polkadotHubTestnet)]: '0xF470c52bb35B13a90c0BFc05b164ECc07f405956',
+  [id(polkadotHub)]: undefined,
+  [id(kusamaHub)]: undefined,
+}
+
+export function flipperAddressForChain(chainId: number): `0x${string}` | undefined {
+  return FLIPPER_ADDRESS_BY_CHAIN_ID[chainId]
+}
+
+export function remarkAddressForChain(chainId: number): `0x${string}` | undefined {
+  return REMARK_ADDRESS_BY_CHAIN_ID[chainId]
+}

--- a/templates/nuxt/app/lib/contracts/flipper.json
+++ b/templates/nuxt/app/lib/contracts/flipper.json
@@ -1,0 +1,46 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "initialValue",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "newValue",
+        "type": "bool"
+      }
+    ],
+    "name": "Flipped",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "flip",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/templates/nuxt/app/lib/contracts/index.ts
+++ b/templates/nuxt/app/lib/contracts/index.ts
@@ -1,0 +1,10 @@
+import flipperAbiJson from './flipper.json'
+import remarkAbiJson from './remark.json'
+
+export {
+  flipperAddressForChain,
+  remarkAddressForChain,
+} from './addresses'
+
+export const flipperAbi = flipperAbiJson
+export const remarkAbi = remarkAbiJson

--- a/templates/nuxt/app/lib/contracts/remark.json
+++ b/templates/nuxt/app/lib/contracts/remark.json
@@ -1,0 +1,40 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "message",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "Remarked",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "message",
+        "type": "string"
+      }
+    ],
+    "name": "remark",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/templates/nuxt/app/lib/web3/chains.ts
+++ b/templates/nuxt/app/lib/web3/chains.ts
@@ -1,0 +1,46 @@
+import { CHAIN_NAMESPACES, type CustomChainConfig } from "@web3auth/modal";
+
+const polkadotLogo = "https://cryptologos.cc/logos/polkadot-new-dot-logo.png";
+
+/** Polkadot Hub TestNet — https://docs.polkadot.com/smart-contracts/connect/ */
+export const polkadotHubTestnet: CustomChainConfig = {
+  chainNamespace: CHAIN_NAMESPACES.EIP155,
+  chainId: "0x190f1b41",
+  rpcTarget: "https://eth-rpc-testnet.polkadot.io/",
+  fallbackRpcTargets: ["https://services.polkadothub-rpc.com/testnet/"],
+  displayName: "Polkadot Hub TestNet",
+  ticker: "PAS",
+  tickerName: "Paseo",
+  blockExplorerUrl: "https://blockscout-testnet.polkadot.io/",
+  decimals: 18,
+  logo: polkadotLogo,
+};
+
+/** Polkadot Hub MainNet — https://docs.polkadot.com/smart-contracts/connect/ */
+export const polkadotHub: CustomChainConfig = {
+  chainNamespace: CHAIN_NAMESPACES.EIP155,
+  chainId: "0x190f1b43",
+  rpcTarget: "https://eth-rpc.polkadot.io/",
+  fallbackRpcTargets: ["https://services.polkadothub-rpc.com/mainnet/"],
+  displayName: "Polkadot Hub",
+  ticker: "DOT",
+  tickerName: "Polkadot",
+  blockExplorerUrl: "https://blockscout.polkadot.io/",
+  decimals: 18,
+  logo: polkadotLogo,
+};
+
+/** Kusama Hub — https://docs.polkadot.com/smart-contracts/connect/ */
+export const kusamaHub: CustomChainConfig = {
+  chainNamespace: CHAIN_NAMESPACES.EIP155,
+  chainId: "0x190f1b42",
+  rpcTarget: "https://eth-rpc-kusama.polkadot.io/",
+  displayName: "Kusama Hub",
+  ticker: "KSM",
+  tickerName: "Kusama",
+  blockExplorerUrl: "https://blockscout-kusama.polkadot.io/",
+  decimals: 18,
+  logo: "https://cryptologos.cc/logos/kusama-ksm-logo.png",
+};
+
+export const polkadotChains = [polkadotHubTestnet, polkadotHub, kusamaHub] as const;

--- a/templates/nuxt/app/lib/web3/config.ts
+++ b/templates/nuxt/app/lib/web3/config.ts
@@ -1,0 +1,21 @@
+import { WEB3AUTH_NETWORK } from '@web3auth/modal'
+import type { Web3AuthContextConfig } from '@web3auth/modal/vue'
+import { polkadotChains, polkadotHubTestnet } from './chains'
+
+/**
+ * Build the Web3Auth context config for the Vue `<Web3AuthProvider>`.
+ * The client id comes from `useRuntimeConfig().public.web3authClientId`
+ * (see nuxt.config.ts / NUXT_PUBLIC_WEB3AUTH_CLIENT_ID).
+ */
+export function createWeb3AuthConfig(clientId: string): Web3AuthContextConfig {
+  return {
+    web3AuthOptions: {
+      clientId,
+      web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_DEVNET,
+      chains: [...polkadotChains],
+      defaultChainId: polkadotHubTestnet.chainId,
+      ssr: false,
+      disableAnalytics: true,
+    },
+  }
+}

--- a/templates/nuxt/app/lib/welcome/data.ts
+++ b/templates/nuxt/app/lib/welcome/data.ts
@@ -1,0 +1,68 @@
+// Static content for the create-dot-app welcome screen — Polkadot-native.
+
+export const CLI = "create-dot-app";
+export const HEADLINE = "Ship your dapp today.";
+
+export interface Feature {
+  title: string;
+  desc: string;
+}
+
+export const FEATURES: Feature[] = [
+  {
+    title: "Embedded wallet",
+    desc: "Connect with Web3Auth (MetaMask embedded wallets), SSR-ready for the App Router.",
+  },
+  {
+    title: "wagmi on Hub",
+    desc: "Read contracts, send transactions, and fetch balances on Polkadot Hub EVM.",
+  },
+  {
+    title: "Hub networks",
+    desc: "Switch between Passet testnet, Polkadot Hub, and Kusama Hub from the UI.",
+  },
+  {
+    title: "EVM on Hub",
+    desc: "Write Solidity, deploy with Hardhat, and interact through wagmi on Polkadot Hub.",
+  },
+  {
+    title: "Hardhat workspace",
+    desc: "Sample Flipper & Remark contracts with compile, test, and deploy scripts.",
+  },
+  {
+    title: "Typed end-to-end",
+    desc: "TypeScript, viem types, and ABIs exported from the contracts package.",
+  },
+];
+
+export const HERO_BLURB =
+  "is a Polkadot Hub starter with embedded wallets, wagmi contract hooks, and Hardhat deploy scripts, already wired together.";
+
+export interface Resource {
+  label: string;
+  meta: string;
+  href: string;
+}
+
+export const RESOURCES: Resource[] = [
+  {
+    label: "Documentation",
+    meta: "Smart contracts on Polkadot Hub",
+    href: "https://docs.polkadot.com/develop/smart-contracts/",
+  },
+  {
+    label: "Polkadot Hub",
+    meta: "Overview, assets & connectivity",
+    href: "https://docs.polkadot.com/reference/polkadot-hub/",
+  },
+  {
+    label: "Get started",
+    meta: "Hardhat, faucets & explorers",
+    href: "https://docs.polkadot.com/smart-contracts/get-started/",
+  },
+  {
+    label: "Discord",
+    meta: "Polkadot developer community",
+    href: "https://discord.gg/polkadot",
+  },
+];

--- a/templates/nuxt/app/lib/welcome/format.ts
+++ b/templates/nuxt/app/lib/welcome/format.ts
@@ -1,0 +1,5 @@
+/** Truncate hex addresses and hashes for compact UI labels. */
+export function formatAddress(value: string, head = 6, tail = 4): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}

--- a/templates/nuxt/app/lib/welcome/networks.ts
+++ b/templates/nuxt/app/lib/welcome/networks.ts
@@ -1,0 +1,72 @@
+// Display metadata for the three networks the starter ships with, keyed to the
+// real wagmi numeric chain IDs derived from lib/web3/chains.ts so the network
+// switch, block watcher, and balance all line up with what wagmi/Web3Auth expose.
+import type { CustomChainConfig } from '@web3auth/modal'
+import { kusamaHub, polkadotHub, polkadotHubTestnet } from '~/lib/web3/chains'
+
+export interface NetworkInfo {
+  id: string
+  chainId: number
+  name: string
+  token: string
+  tag: string
+  color: string
+  rpc: string
+  chain: string
+  explorer: string
+}
+
+const numericId = (chain: CustomChainConfig) => Number.parseInt(chain.chainId, 16)
+
+export const NETWORKS: NetworkInfo[] = [
+  {
+    id: 'pas-hub',
+    chainId: numericId(polkadotHubTestnet),
+    name: 'Polkadot Hub Testnet',
+    token: 'PAS',
+    tag: 'TESTNET',
+    color: '#56B4D3',
+    rpc: polkadotHubTestnet.rpcTarget,
+    chain: 'Passet Hub',
+    explorer: polkadotHubTestnet.blockExplorerUrl ?? '',
+  },
+  {
+    id: 'dot-hub',
+    chainId: numericId(polkadotHub),
+    name: 'Polkadot Hub',
+    token: 'DOT',
+    tag: 'MAINNET',
+    color: '#E6007A',
+    rpc: polkadotHub.rpcTarget,
+    chain: 'Polkadot Asset Hub',
+    explorer: polkadotHub.blockExplorerUrl ?? '',
+  },
+  {
+    id: 'ksm-hub',
+    chainId: numericId(kusamaHub),
+    name: 'Kusama Hub',
+    token: 'KSM',
+    tag: 'CANARY',
+    color: '#7D4DAE',
+    rpc: kusamaHub.rpcTarget,
+    chain: 'Kusama Asset Hub',
+    explorer: kusamaHub.blockExplorerUrl ?? '',
+  },
+]
+
+export const TESTNET = NETWORKS[0]!
+
+export function networkByChainId(chainId: number | undefined): NetworkInfo {
+  return NETWORKS.find((n) => n.chainId === chainId) ?? NETWORKS[0]!
+}
+
+/** Strip the protocol for the compact endpoint label used across the UI. */
+export function rpcHost(rpc: string): string {
+  return rpc.replace(/^https?:\/\//, '').replace(/^wss?:\/\//, '').replace(/\/$/, '')
+}
+
+/** Block-explorer URL for a transaction hash, or undefined if the chain has no explorer. */
+export function explorerTxUrl(net: NetworkInfo, hash: string): string | undefined {
+  if (!net.explorer) return undefined
+  return `${net.explorer.replace(/\/$/, '')}/tx/${hash}`
+}

--- a/templates/nuxt/app/lib/welcome/shared.ts
+++ b/templates/nuxt/app/lib/welcome/shared.ts
@@ -1,0 +1,28 @@
+import { CLI } from "./data";
+
+export type WriteActionKey = "flip" | "remark";
+
+export const WRITE_STEPS = ["Ready", "Broadcast", "InBlock", "Finalized"] as const;
+
+export const REMARK_MESSAGE = `gm from ${CLI}`;
+
+export const WRITE_ACTIONS = {
+  flip: {
+    key: "flip" as WriteActionKey,
+    tab: "flipper.flip",
+    title: "Call the flipper contract",
+    cta: "Call contract",
+  },
+  remark: {
+    key: "remark" as WriteActionKey,
+    tab: "system.remark",
+    title: "Submit a sample extrinsic",
+    cta: "Send extrinsic",
+  },
+} as const;
+
+export const EYEBROW =
+  "font-mono text-[11px] font-semibold tracking-[0.12em] text-(--faint)";
+
+export const LIVE_CELL =
+  "p-[26px_30px] welcome-sm:p-[22px_20px]";

--- a/templates/nuxt/app/lib/welcome/theme.ts
+++ b/templates/nuxt/app/lib/welcome/theme.ts
@@ -1,0 +1,51 @@
+// Color tokens for the editorial welcome screen.
+// Light/dark token sets are oklch so accent + contrast stay coherent in both modes.
+// Values are exposed as CSS variables on the welcome root for Tailwind arbitrary utilities.
+
+import type { CSSProperties } from 'vue'
+
+export interface Tokens {
+  paper: string
+  ink: string
+  dim: string
+  faint: string
+  line: string
+  card: string
+}
+
+export function tokens(dark: boolean): Tokens {
+  return dark
+    ? {
+        paper: 'oklch(0.17 0.008 70)',
+        ink: 'oklch(0.95 0.006 80)',
+        dim: 'oklch(0.7 0.012 75)',
+        faint: 'oklch(0.56 0.012 75)',
+        line: 'oklch(0.3 0.01 70)',
+        card: 'oklch(0.205 0.008 70)',
+      }
+    : {
+        paper: 'oklch(0.972 0.006 80)',
+        ink: 'oklch(0.22 0.012 60)',
+        dim: 'oklch(0.45 0.012 60)',
+        faint: 'oklch(0.6 0.01 60)',
+        line: 'oklch(0.88 0.008 70)',
+        card: 'oklch(0.995 0.004 80)',
+      }
+}
+
+// Curated accent swatches: vermilion, electric blue, green, violet, amber.
+export const ACCENTS = ['#D9542B', '#2F6BFF', '#18A058', '#7A5AE0', '#E0A92F']
+export const DEFAULT_ACCENT = ACCENTS[0]!
+
+/** CSS custom properties consumed by Tailwind `var(--*)` utilities on the welcome root. */
+export function themeVars(c: Tokens, acc: string): CSSProperties {
+  return {
+    '--paper': c.paper,
+    '--ink': c.ink,
+    '--dim': c.dim,
+    '--faint': c.faint,
+    '--line': c.line,
+    '--card': c.card,
+    '--acc': acc,
+  } as CSSProperties
+}

--- a/templates/nuxt/app/pages/index.vue
+++ b/templates/nuxt/app/pages/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import AppWelcome from '~/components/welcome/AppWelcome.vue'
+
+useHead({
+  title: 'create-dot-app · Welcome',
+})
+</script>
+
+<template>
+  <AppWelcome />
+</template>

--- a/templates/nuxt/app/plugins/vue-query.ts
+++ b/templates/nuxt/app/plugins/vue-query.ts
@@ -1,0 +1,9 @@
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
+
+// wagmi's Vue composables read/write through TanStack Query, so the QueryClient
+// must be installed app-wide before any of them run. The Web3Auth + wagmi
+// providers live under this in the component tree (see app.vue).
+export default defineNuxtPlugin((nuxtApp) => {
+  const queryClient = new QueryClient()
+  nuxtApp.vueApp.use(VueQueryPlugin, { queryClient })
+})

--- a/templates/nuxt/config/empty-module.js
+++ b/templates/nuxt/config/empty-module.js
@@ -1,0 +1,2 @@
+/** Stub for optional dependencies that are not used in the browser. */
+export default {}

--- a/templates/nuxt/config/metamask-analytics-stub.js
+++ b/templates/nuxt/config/metamask-analytics-stub.js
@@ -1,0 +1,8 @@
+/** No-op stub for @metamask/sdk-analytics — avoids telemetry fetch errors in local dev. */
+export const analytics = {
+  enable() {},
+  setGlobalProperty() {},
+  track() {},
+}
+
+export default { analytics }

--- a/templates/nuxt/contracts/.gitignore
+++ b/templates/nuxt/contracts/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.env
+
+/cache
+/artifacts
+/typechain-types
+
+/coverage
+/coverage.json
+
+ignition/deployments

--- a/templates/nuxt/contracts/README.md
+++ b/templates/nuxt/contracts/README.md
@@ -1,0 +1,70 @@
+# Smart contracts (Hardhat 3 + PolkaVM)
+
+Solidity workspace for [Polkadot Hub](https://docs.polkadot.com/smart-contracts/). Contracts are compiled to **PolkaVM** bytecode with [`@avalix/hardhat-polkavm`](https://www.npmjs.com/package/@avalix/hardhat-polkavm) (Parity's `resolc` / revive compiler) — the bytecode Polkadot Hub actually executes.
+
+The default network (`polkadotHubTestnet`) matches **Polkadot Hub TestNet** used by the Nuxt app (`chainId` `420420417` / `0x190f1b41`).
+
+## Prerequisites
+
+- Node.js 22+ (LTS)
+- npm
+
+## Setup
+
+From the **project root** (monorepo — `npm install` installs this workspace too):
+
+```bash
+npm install
+```
+
+Store your deployer private key in Hardhat's encrypted keystore. Run from the project root or from `contracts/`:
+
+```bash
+npm exec -w hardhat hardhat keystore set PRIVATE_KEY
+```
+
+An exported `PRIVATE_KEY` env var also works as a fallback.
+
+## Scripts
+
+From the project root:
+
+```bash
+npm run compile:contracts
+npm run test:contracts
+npm run deploy:contracts
+```
+
+Or from this directory (`contracts/`):
+
+```bash
+npm run compile   # compile Solidity to PolkaVM and export ABIs to ../app/lib/contracts/
+npm test          # integration tests (see below)
+npm run deploy    # deploy Flipper + Remark via Ignition to Polkadot Hub TestNet
+```
+
+Deploy requires `PRIVATE_KEY` to be set and the account funded with test PAS ([faucet](https://faucet.polkadot.io/)).
+
+## Tests
+
+PolkaVM bytecode does not run on Hardhat's local EVM simulated network, so the tests exercise the contracts **live** on Polkadot Hub TestNet. Deploy first, then point the tests at the deployed addresses:
+
+```bash
+FLIPPER_ADDRESS=0x... REMARK_ADDRESS=0x... npm test
+```
+
+Each test is skipped when its address is unset, so a bare `npm test` passes. The live tests send real transactions and spend PAS with the configured account.
+
+## Switch back to EVM
+
+Remove the `resolc` block from [`hardhat.config.ts`](./hardhat.config.ts) to compile with `solc` for the EVM as usual.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `contracts/Flipper.sol` | Boolean flipper — `flipper.flip()` in the welcome demo |
+| `contracts/Remark.sol` | On-chain remark — `system.remark()` in the welcome demo |
+| `ignition/modules/DemoModule.ts` | Deploys both contracts |
+| `test/` | Live integration tests (viem + `node:test`) |
+| `hardhat.config.ts` | Plugins, networks, `resolc` (PolkaVM) compiler |

--- a/templates/nuxt/contracts/contracts/Flipper.sol
+++ b/templates/nuxt/contracts/contracts/Flipper.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Minimal boolean flipper — mirrors the ink! flipper used in create-dot-app demos.
+contract Flipper {
+    bool private _value;
+
+    event Flipped(bool newValue);
+
+    constructor(bool initialValue) {
+        _value = initialValue;
+    }
+
+    function flip() external {
+        _value = !_value;
+        emit Flipped(_value);
+    }
+
+    function get() external view returns (bool) {
+        return _value;
+    }
+}

--- a/templates/nuxt/contracts/contracts/Remark.sol
+++ b/templates/nuxt/contracts/contracts/Remark.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice On-chain remark — EVM stand-in for `system.remark` in the welcome demo.
+contract Remark {
+    event Remarked(address indexed sender, string message, uint256 timestamp);
+
+    function remark(string calldata message) external {
+        require(bytes(message).length > 0, "Message cannot be empty");
+        emit Remarked(msg.sender, message, block.timestamp);
+    }
+}

--- a/templates/nuxt/contracts/hardhat.config.ts
+++ b/templates/nuxt/contracts/hardhat.config.ts
@@ -1,0 +1,42 @@
+import hardhatIgnition from '@nomicfoundation/hardhat-ignition'
+import hardhatKeystore from '@nomicfoundation/hardhat-keystore'
+import hardhatNodeTestRunner from '@nomicfoundation/hardhat-node-test-runner'
+import hardhatViem from '@nomicfoundation/hardhat-viem'
+import { configVariable, defineConfig } from 'hardhat/config'
+import hardhatPolkaVM from '@avalix/hardhat-polkavm'
+
+// https://docs.polkadot.com/smart-contracts/dev-environments/hardhat/
+export default defineConfig({
+  plugins: [
+    hardhatPolkaVM,
+    hardhatKeystore,
+    hardhatIgnition,
+    hardhatNodeTestRunner,
+    hardhatViem,
+  ],
+  solidity: '0.8.29',
+  // The presence of this block switches Solidity compilation from solc (EVM) to
+  // resolc (PolkaVM) — the bytecode Polkadot Hub actually runs. Remove it to
+  // compile for the EVM as usual.
+  resolc: {
+    // "npm" is self-contained and works on every platform. Switch to "binary"
+    // for the faster native compiler on macOS / Linux x64 / Windows x64.
+    compilerSource: 'npm',
+    optimizer: {
+      enabled: true,
+      runs: 200,
+    },
+  },
+  networks: {
+    // Polkadot Hub TestNet — chainId 420420417 / 0x190f1b41, the chain the
+    // Nuxt app talks to. Token: PAS · Faucet: https://faucet.polkadot.io/
+    polkadotHubTestnet: {
+      type: 'http',
+      url: 'https://services.polkadothub-rpc.com/testnet',
+      chainId: 420420417,
+      // Stored in the encrypted keystore: `npx hardhat keystore set PRIVATE_KEY`
+      // (see the README). An exported PRIVATE_KEY env var also works.
+      accounts: [configVariable('PRIVATE_KEY')],
+    },
+  },
+})

--- a/templates/nuxt/contracts/ignition/modules/DemoModule.ts
+++ b/templates/nuxt/contracts/ignition/modules/DemoModule.ts
@@ -1,0 +1,8 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
+
+export default buildModule('DemoModule', (m) => {
+  const flipper = m.contract('Flipper', [false])
+  const remark = m.contract('Remark')
+
+  return { flipper, remark }
+})

--- a/templates/nuxt/contracts/package.json
+++ b/templates/nuxt/contracts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "hardhat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Hardhat workspace for Polkadot Hub smart contracts (PolkaVM)",
+  "license": "MIT",
+  "scripts": {
+    "compile": "hardhat compile && node scripts/export-abi.mjs",
+    "clean": "hardhat clean",
+    "test": "hardhat test",
+    "deploy": "hardhat ignition deploy ./ignition/modules/DemoModule.ts --network polkadotHubTestnet"
+  },
+  "devDependencies": {
+    "@avalix/hardhat-polkavm": "^0.2.1",
+    "@nomicfoundation/hardhat-ignition": "^3.1.7",
+    "@nomicfoundation/hardhat-keystore": "^3.0.12",
+    "@nomicfoundation/hardhat-node-test-runner": "^3.0.17",
+    "@nomicfoundation/hardhat-viem": "^3.0.9",
+    "@types/node": "^22.19.19",
+    "hardhat": "^3.9.0",
+    "typescript": "^5.9.3",
+    "viem": "^2.52.0"
+  }
+}

--- a/templates/nuxt/contracts/scripts/export-abi.mjs
+++ b/templates/nuxt/contracts/scripts/export-abi.mjs
@@ -1,0 +1,13 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const contractsRoot = path.join(here, '..')
+const outDir = path.join(contractsRoot, '..', 'app', 'lib', 'contracts')
+
+for (const name of ['Flipper', 'Remark']) {
+  const artifactPath = path.join(contractsRoot, 'artifacts/contracts', `${name}.sol`, `${name}.json`)
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'))
+  fs.writeFileSync(path.join(outDir, `${name.toLowerCase()}.json`), `${JSON.stringify(artifact.abi, null, 2)}\n`)
+}

--- a/templates/nuxt/contracts/test/Flipper.test.ts
+++ b/templates/nuxt/contracts/test/Flipper.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { network } from 'hardhat'
+import { getAddress } from 'viem'
+
+// Integration test against the Flipper deployed on Polkadot Hub TestNet by
+// `npm run deploy`. PolkaVM bytecode does not run on the local EVM simulated
+// network, so the contract is exercised live. It sends a real transaction
+// (costs PAS) with the configured account — set FLIPPER_ADDRESS to the deployed
+// address and provide a funded PRIVATE_KEY (env var or `hardhat keystore`).
+// Without FLIPPER_ADDRESS the test is skipped, so `npm test` stays green.
+const FLIPPER_ADDRESS = process.env.FLIPPER_ADDRESS
+
+describe('Flipper on Polkadot Hub TestNet', () => {
+  it(
+    'flip() toggles get()',
+    { timeout: 180_000, skip: !FLIPPER_ADDRESS },
+    async () => {
+      const { viem } = await network.getOrCreate('polkadotHubTestnet')
+      const publicClient = await viem.getPublicClient()
+      const flipper = await viem.getContractAt('Flipper', getAddress(FLIPPER_ADDRESS!))
+
+      const before = await flipper.read.get()
+
+      const hash = await flipper.write.flip()
+      await publicClient.waitForTransactionReceipt({ hash })
+
+      assert.equal(await flipper.read.get(), !before)
+    },
+  )
+})

--- a/templates/nuxt/contracts/test/Remark.test.ts
+++ b/templates/nuxt/contracts/test/Remark.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { network } from 'hardhat'
+import { getAddress } from 'viem'
+
+// Integration test against the Remark deployed on Polkadot Hub TestNet by
+// `npm run deploy`. PolkaVM bytecode does not run on the local EVM simulated
+// network, so the contract is exercised live. It sends a real transaction
+// (costs PAS) with the configured account — set REMARK_ADDRESS to the deployed
+// address and provide a funded PRIVATE_KEY (env var or `hardhat keystore`).
+// Without REMARK_ADDRESS the test is skipped, so `npm test` stays green.
+const REMARK_ADDRESS = process.env.REMARK_ADDRESS
+
+describe('Remark on Polkadot Hub TestNet', () => {
+  it(
+    'remark() emits Remarked',
+    { timeout: 180_000, skip: !REMARK_ADDRESS },
+    async () => {
+      const { viem } = await network.getOrCreate('polkadotHubTestnet')
+      const publicClient = await viem.getPublicClient()
+      const remark = await viem.getContractAt('Remark', getAddress(REMARK_ADDRESS!))
+
+      const hash = await remark.write.remark(['gm from create-dot-app'])
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+
+      const events = await remark.getEvents.Remarked()
+      assert.equal(receipt.status, 'success')
+      assert.ok(events.length >= 0)
+    },
+  )
+})

--- a/templates/nuxt/contracts/tsconfig.json
+++ b/templates/nuxt/contracts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["es2023"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": [
+    "hardhat.config.ts",
+    "ignition",
+    "test",
+    "artifacts/**/*.d.ts"
+  ]
+}

--- a/templates/nuxt/eslint.config.mjs
+++ b/templates/nuxt/eslint.config.mjs
@@ -1,0 +1,9 @@
+// Nuxt generates the base flat config (.nuxt/eslint.config.mjs) via the
+// @nuxt/eslint module during `nuxt prepare`. Extend it with your own rules here.
+import withNuxt from './.nuxt/eslint.config.mjs'
+
+export default withNuxt(
+  {
+    ignores: ['.nuxt/**', '.output/**', 'dist/**', 'node_modules/**', 'contracts/**'],
+  },
+)

--- a/templates/nuxt/nuxt.config.ts
+++ b/templates/nuxt/nuxt.config.ts
@@ -1,0 +1,79 @@
+import { fileURLToPath } from 'node:url'
+import tailwindcss from '@tailwindcss/vite'
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  compatibilityDate: '2025-01-01',
+  devtools: { enabled: true },
+
+  // Web3Auth + wagmi are browser-only, so the app runs as a client-rendered SPA.
+  // Nuxt still serves a fast static shell (head, fonts) before the app boots.
+  ssr: false,
+
+  modules: ['@nuxt/eslint'],
+
+  css: ['~/assets/css/main.css'],
+
+  // Exposed to the client as `useRuntimeConfig().public.web3authClientId`.
+  // The default is a demo Sapphire Devnet Client ID for quick local testing —
+  // get your own at https://dashboard.web3auth.io and override it with
+  // NUXT_PUBLIC_WEB3AUTH_CLIENT_ID in .env.
+  runtimeConfig: {
+    public: {
+      web3authClientId:
+        'BHgArYmWwSeq21czpcarYh0EVq2WWOzflX-NTK-tY1-1pauPzHKRRLgpABkmYiIV_og9jAvoIxQ8L3Smrwe04Lw',
+    },
+  },
+
+  app: {
+    head: {
+      title: 'create-dot-app · Welcome',
+      htmlAttrs: { lang: 'en' },
+      meta: [
+        { charset: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        {
+          name: 'description',
+          content:
+            'Polkadot-native dapp starter — wallet connection, type-safe hooks and deploy scripts, already wired together.',
+        },
+      ],
+      link: [
+        {
+          rel: 'preconnect',
+          href: 'https://fonts.googleapis.com',
+        },
+        {
+          rel: 'preconnect',
+          href: 'https://fonts.gstatic.com',
+          crossorigin: '',
+        },
+        {
+          rel: 'stylesheet',
+          href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap',
+        },
+      ],
+    },
+  },
+
+  vite: {
+    plugins: [tailwindcss()],
+    resolve: {
+      // Optional dependencies of Web3Auth / wagmi that aren't used in the
+      // browser bundle — stub them out so Vite doesn't try to bundle them.
+      alias: {
+        'pino-pretty': fileURLToPath(new URL('./config/empty-module.js', import.meta.url)),
+        '@react-native-async-storage/async-storage': fileURLToPath(
+          new URL('./config/empty-module.js', import.meta.url),
+        ),
+        '@metamask/sdk-analytics': fileURLToPath(
+          new URL('./config/metamask-analytics-stub.js', import.meta.url),
+        ),
+      },
+    },
+    optimizeDeps: {
+      // Pre-bundle the heavier web3 deps so dev server cold starts stay fast.
+      include: ['@web3auth/modal', '@wagmi/vue', '@tanstack/vue-query', 'viem'],
+    },
+  },
+})

--- a/templates/nuxt/package.json
+++ b/templates/nuxt/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "nuxt-hub",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "contracts"
+  ],
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "postinstall": "nuxt prepare",
+    "typecheck": "nuxt typecheck",
+    "lint": "eslint .",
+    "compile:contracts": "cd contracts && npm run compile",
+    "test:contracts": "cd contracts && npm run test",
+    "deploy:contracts": "cd contracts && npm run deploy"
+  },
+  "dependencies": {
+    "@tanstack/vue-query": "^5.101.0",
+    "@wagmi/vue": "^0.5.17",
+    "@web3auth/modal": "^10.16.0",
+    "nuxt": "^4.4.8",
+    "viem": "^2.52.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@nuxt/eslint": "^1.9.0",
+    "@tailwindcss/vite": "^4",
+    "@types/node": "^22.19.19",
+    "eslint": "^9.39.4",
+    "tailwindcss": "^4",
+    "typescript": "^5",
+    "vue-tsc": "^2.2.0"
+  }
+}

--- a/templates/nuxt/pnpm-workspace.yaml
+++ b/templates/nuxt/pnpm-workspace.yaml
@@ -1,0 +1,32 @@
+# pnpm ignores the package.json "workspaces" field (used by npm/bun/yarn) and
+# reads its workspace layout from here instead. Keep this list in sync with it.
+packages:
+  - contracts
+
+# pnpm gates dependency build scripts (native addons and postinstall steps)
+# behind an allow-list, so a fresh install would otherwise stop and ask before
+# running them. npm, bun, and yarn run these by default; approving them here
+# keeps `pnpm install` non-interactive. `allowBuilds` is the pnpm v11+ form and
+# `onlyBuiltDependencies` is the v10 form, so both are listed to cover either.
+allowBuilds:
+  '@parcel/watcher': true
+  bufferutil: true
+  esbuild: true
+  keccak: true
+  secp256k1: true
+  sharp: true
+  tiny-secp256k1: true
+  unrs-resolver: true
+  utf-8-validate: true
+  vue-demi: true
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - bufferutil
+  - esbuild
+  - keccak
+  - secp256k1
+  - sharp
+  - tiny-secp256k1
+  - unrs-resolver
+  - utf-8-validate
+  - vue-demi

--- a/templates/nuxt/tsconfig.json
+++ b/templates/nuxt/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "files": [],
+  "references": [
+    { "path": "./.nuxt/tsconfig.app.json" },
+    { "path": "./.nuxt/tsconfig.server.json" },
+    { "path": "./.nuxt/tsconfig.shared.json" },
+    { "path": "./.nuxt/tsconfig.node.json" }
+  ]
+}


### PR DESCRIPTION
Adds `templates/nuxt`, a faithful Nuxt (Vue 3) port of the Next.js Solidity / Polkadot Hub EVM starter, reproducing the welcome screen (live block watcher, network switch, Connect Wallet, sample contract write) with `@wagmi/vue` + `@web3auth/modal/vue` + `@tanstack/vue-query` while reusing the Hardhat/PolkaVM `contracts/` workspace. It runs as a client SPA (`ssr: false`) because the web3 stack is browser-only. Registers `nuxt` ("Solidity (Nuxt)") in the CLI template selector with new tests, and wires it into the `package-manager` PR workflow. Also updates the CONTRIBUTING structure tree and the CLI README template listings. Verified end-to-end on the npm path: install, lint, typecheck, build, and `compile:contracts` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)