### PR TITLE
fix(next-template): allow esbuild build script in pnpm allow-list

### DIFF
--- a/templates/next/pnpm-workspace.yaml
+++ b/templates/next/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
 # `onlyBuiltDependencies` is the v10 form, so both are listed to cover either.
 allowBuilds:
   bufferutil: true
+  esbuild: true
   keccak: true
   secp256k1: true
   sharp: true
@@ -18,6 +19,7 @@ allowBuilds:
   utf-8-validate: true
 onlyBuiltDependencies:
   - bufferutil
+  - esbuild
   - keccak
   - secp256k1
   - sharp


### PR DESCRIPTION
## Problem

The `templates/next` pnpm CI job fails at `pnpm install` with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.1
```

The dependency upgrade in #331 pulled in `esbuild@0.28.1` as a transitive dependency. It ships a build script, and pnpm 10+ exits non-zero when a build script is ignored, so the install step fails.

Only `templates/next` was affected — `next-papi` and `nuxt` already list `esbuild` in their allow-lists.

## Fix

Add `esbuild` to both allow-lists in `templates/next/pnpm-workspace.yaml`:

- `allowBuilds:` (pnpm v11+ form)
- `onlyBuiltDependencies:` (pnpm v10 form)

This matches how `next-papi` and `nuxt` already handle it and keeps `pnpm install` non-interactive in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)